### PR TITLE
fix: 月次固定費の集計バグ修正・明細一覧のUI改善

### DIFF
--- a/src/app/monthly/page.tsx
+++ b/src/app/monthly/page.tsx
@@ -4,8 +4,8 @@ import { useState, useEffect, useMemo } from "react"
 import Link from "next/link"
 import { AppLayout } from "@/components/app-layout"
 import { MonthSelector } from "@/components/month-selector"
-import { formatCurrency, getTransactions, getAccounts, getCategories, getCurrentMonth, shiftMonth } from "@/lib/data"
-import { Transaction, Account, Category } from "@/lib/types"
+import { formatCurrency, getTransactions, getAccounts, getCategories, getTemplates, getCurrentMonth, shiftMonth } from "@/lib/data"
+import { Transaction, Account, Category, RecurringTemplate } from "@/lib/types"
 import { cn } from "@/lib/utils"
 
 // 投資カテゴリは名前ベースで判定（DBにis_investmentフラグがないため）
@@ -53,6 +53,7 @@ export default function MonthlyDetailsPage() {
   const [transactions, setTransactions] = useState<Transaction[]>([])
   const [accounts, setAccounts] = useState<Account[]>([])
   const [categories, setCategories] = useState<Category[]>([])
+  const [templates, setTemplates] = useState<RecurringTemplate[]>([])
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
@@ -61,18 +62,23 @@ export default function MonthlyDetailsPage() {
       getTransactions(currentMonth),
       getAccounts(),
       getCategories(),
-    ]).then(([txs, accs, cats]) => {
+      getTemplates(),
+    ]).then(([txs, accs, cats, tpls]) => {
       setTransactions(txs)
       setAccounts(accs)
       setCategories(cats)
+      setTemplates(tpls)
     }).finally(() => setLoading(false))
   }, [currentMonth])
 
   const monthlyBreakdown = useMemo(() => {
-    // DBのis_fixedフラグから固定費カテゴリ名のセットを構築
-    const fixedCategoryNames = new Set(
-      categories.filter((c) => c.is_fixed).map((c) => c.name)
-    )
+    // 固定費カテゴリIDの判定:
+    //   1. categories.is_fixed = true のもの
+    //   2. recurring_templates に登録されているカテゴリ（ユーザーが固定費として登録したもの）
+    const fixedCategoryIds = new Set([
+      ...categories.filter((c) => c.is_fixed).map((c) => c.id),
+      ...templates.map((t) => t.category_id),
+    ])
 
     const groupByCategory = (txs: Transaction[]) => {
       const grouped = txs.reduce<Record<string, number>>((acc, t) => {
@@ -85,9 +91,9 @@ export default function MonthlyDetailsPage() {
     const incomeTxs = transactions.filter((t) => t.type === "income")
     const expenseTxs = transactions.filter((t) => t.type === "expense")
     const investmentTxs = expenseTxs.filter((t) => INVESTMENT_CATEGORIES.has(t.category))
-    const fixedTxs = expenseTxs.filter((t) => fixedCategoryNames.has(t.category))
+    const fixedTxs = expenseTxs.filter((t) => fixedCategoryIds.has(t.category_id))
     const variableTxs = expenseTxs.filter(
-      (t) => !fixedCategoryNames.has(t.category) && !INVESTMENT_CATEGORIES.has(t.category)
+      (t) => !fixedCategoryIds.has(t.category_id) && !INVESTMENT_CATEGORIES.has(t.category)
     )
 
     return {
@@ -108,7 +114,7 @@ export default function MonthlyDetailsPage() {
         items: groupByCategory(investmentTxs),
       },
     }
-  }, [transactions, categories])
+  }, [transactions, categories, templates])
 
   const totalExpense = monthlyBreakdown.fixedExpenses.total + monthlyBreakdown.variableExpenses.total
   const balance = monthlyBreakdown.income.total - totalExpense - monthlyBreakdown.investments.total

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -7,7 +7,7 @@ import { getTransactions, getCategories, getAccounts, formatCurrency, formatDate
 import { Transaction, Category, Account, TransactionType } from "@/lib/types"
 import { supabase } from "@/lib/supabase"
 import { cn } from "@/lib/utils"
-import { SlidersHorizontal, X, Pencil, Trash2, Calendar } from "lucide-react"
+import { SlidersHorizontal, X, Pencil, Trash2, Calendar, ArrowUpDown } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
@@ -29,6 +29,7 @@ import {
 export default function TransactionsPage() {
   const [currentMonth, setCurrentMonth] = useState(getCurrentMonth())
   const [showFilters, setShowFilters] = useState(false)
+  const [sortOrder, setSortOrder] = useState<"desc" | "asc">("desc")
   const [categoryFilter, setCategoryFilter] = useState<string>("all")
   const [accountFilter, setAccountFilter] = useState<string>("all")
   const [typeFilter, setTypeFilter] = useState<string>("all")
@@ -106,10 +107,13 @@ export default function TransactionsPage() {
     return true
   }), [transactions, categoryFilter, accountFilter, typeFilter])
 
-  const groupedTransactions = useMemo(
-    () => groupTransactionsByDate(filteredTransactions),
-    [filteredTransactions]
-  )
+  const groupedTransactions = useMemo(() => {
+    const grouped = groupTransactionsByDate(filteredTransactions)
+    if (sortOrder === "asc") {
+      return new Map([...grouped.entries()].reverse())
+    }
+    return grouped
+  }, [filteredTransactions, sortOrder])
 
   const hasActiveFilters = categoryFilter !== "all" || accountFilter !== "all" || typeFilter !== "all"
 
@@ -131,16 +135,25 @@ export default function TransactionsPage() {
             </h1>
             <div className="flex items-center gap-2">
               <button
+                onClick={() => setSortOrder((o) => o === "desc" ? "asc" : "desc")}
+                className="flex h-8 items-center gap-1.5 rounded-full px-3 text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                aria-label="並び替え"
+              >
+                <ArrowUpDown className="h-3.5 w-3.5" />
+                {sortOrder === "desc" ? "新しい順" : "古い順"}
+              </button>
+              <button
                 onClick={() => setShowFilters(!showFilters)}
                 className={cn(
-                  "flex h-8 w-8 items-center justify-center rounded-full transition-colors",
+                  "flex h-8 items-center gap-1.5 rounded-full px-3 text-xs transition-colors",
                   showFilters || hasActiveFilters
                     ? "bg-foreground text-background"
                     : "text-muted-foreground hover:text-foreground hover:bg-muted"
                 )}
-                aria-label="フィルタ"
+                aria-label="絞り込み"
               >
-                <SlidersHorizontal className="h-4 w-4" />
+                <SlidersHorizontal className="h-3.5 w-3.5" />
+                絞り込み
               </button>
               <MonthSelector
                 month={currentMonth}
@@ -166,38 +179,47 @@ export default function TransactionsPage() {
               )}
             </div>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-              <Select value={typeFilter} onValueChange={setTypeFilter}>
-                <SelectTrigger className="rounded-xl border-0 bg-muted/50">
-                  <SelectValue placeholder="種類" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">すべて</SelectItem>
-                  <SelectItem value="income">収入</SelectItem>
-                  <SelectItem value="expense">支出</SelectItem>
-                </SelectContent>
-              </Select>
-              <Select value={categoryFilter} onValueChange={setCategoryFilter}>
-                <SelectTrigger className="rounded-xl border-0 bg-muted/50">
-                  <SelectValue placeholder="カテゴリ" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">すべて</SelectItem>
-                  {categories.map((c) => (
-                    <SelectItem key={c.id} value={c.id}>{c.icon} {c.name}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <Select value={accountFilter} onValueChange={setAccountFilter}>
-                <SelectTrigger className="rounded-xl border-0 bg-muted/50">
-                  <SelectValue placeholder="口座" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">すべて</SelectItem>
-                  {accounts.map((a) => (
-                    <SelectItem key={a.id} value={a.id}>{a.icon} {a.name}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <div className="space-y-1.5">
+                <p className="text-[10px] tracking-wide uppercase text-muted-foreground px-1">種類</p>
+                <Select value={typeFilter} onValueChange={setTypeFilter}>
+                  <SelectTrigger className="rounded-xl border-0 bg-muted/50">
+                    <SelectValue placeholder="すべて" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">すべて</SelectItem>
+                    <SelectItem value="income">収入</SelectItem>
+                    <SelectItem value="expense">支出</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1.5">
+                <p className="text-[10px] tracking-wide uppercase text-muted-foreground px-1">カテゴリ</p>
+                <Select value={categoryFilter} onValueChange={setCategoryFilter}>
+                  <SelectTrigger className="rounded-xl border-0 bg-muted/50">
+                    <SelectValue placeholder="すべて" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">すべて</SelectItem>
+                    {categories.map((c) => (
+                      <SelectItem key={c.id} value={c.id}>{c.icon} {c.name}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1.5">
+                <p className="text-[10px] tracking-wide uppercase text-muted-foreground px-1">口座</p>
+                <Select value={accountFilter} onValueChange={setAccountFilter}>
+                  <SelectTrigger className="rounded-xl border-0 bg-muted/50">
+                    <SelectValue placeholder="すべて" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">すべて</SelectItem>
+                    {accounts.map((a) => (
+                      <SelectItem key={a.id} value={a.id}>{a.icon} {a.name}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary

- 月次画面で固定費が常に0になるバグを修正
- 明細一覧に新しい順/古い順の並び替えボタンを追加
- 絞り込みパネルの各セレクターにラベルを追加

## 変更内容

**`src/app/monthly/page.tsx`**
- `recurring_templates` に登録されているカテゴリを固定費として扱うよう修正（`is_fixed` フラグとテンプレートの両方を参照）
- カテゴリ判定をカテゴリ名の文字列一致 → `category_id` での一致に変更（より確実な判定）
- `getTemplates()` を追加でロードし、`useMemo` の依存配列にも追加

**`src/app/transactions/page.tsx`**
- 「新しい順 / 古い順」切り替えボタンを追加（`ArrowUpDown` アイコン + テキスト）
- 絞り込みボタンに「絞り込み」テキストラベルを追加（アイコンのみから変更）
- 絞り込みパネルの種類・カテゴリ・口座セレクターに上部ラベルを追加

## Test plan

- [ ] 固定費テンプレートを登録して一括反映後、月次画面で固定費に正しく集計されることを確認
- [ ] `is_fixed: true` のカテゴリの取引も引き続き固定費として表示されることを確認
- [ ] 明細一覧で「新しい順」「古い順」が切り替わることを確認
- [ ] 絞り込みパネルを開いたとき、各セレクターにラベルが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)