### PR TITLE
feat: 口座編集ダイアログに初期残高の変更機能を追加

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -60,6 +60,7 @@ export default function SettingsPage() {
   // 口座編集
   const [editingAccount, setEditingAccount] = useState<Account | null>(null)
   const [editAccountName, setEditAccountName] = useState("")
+  const [editAccountBalance, setEditAccountBalance] = useState("")
 
   // テンプレート追加
   const [newTplName, setNewTplName] = useState("")
@@ -160,7 +161,10 @@ export default function SettingsPage() {
   // 口座名変更
   async function handleRenameAccount() {
     if (!editingAccount || !editAccountName.trim()) return
-    const { error } = await supabase.from("accounts").update({ name: editAccountName.trim() }).eq("id", editingAccount.id)
+    const { error } = await supabase.from("accounts").update({
+      name: editAccountName.trim(),
+      opening_balance: parseInt(editAccountBalance) || 0,
+    }).eq("id", editingAccount.id)
     if (error) { alert("変更に失敗しました"); return }
     setEditingAccount(null)
     loadData()
@@ -423,7 +427,7 @@ export default function SettingsPage() {
                         </div>
                         <div className="flex items-center gap-1">
                           <button
-                            onClick={() => { setEditingAccount(account); setEditAccountName(account.name) }}
+                            onClick={() => { setEditingAccount(account); setEditAccountName(account.name); setEditAccountBalance(String(account.opening_balance ?? 0)) }}
                             className="p-2 text-muted-foreground hover:text-foreground transition-colors"
                           >
                             <Pencil className="h-4 w-4" />
@@ -550,12 +554,14 @@ export default function SettingsPage() {
         </DialogContent>
       </Dialog>
 
-      {/* 口座名変更 Dialog */}
+      {/* 口座編集 Dialog */}
       <Dialog open={!!editingAccount} onOpenChange={(o) => { if (!o) setEditingAccount(null) }}>
         <DialogContent className="rounded-2xl max-w-sm">
-          <DialogHeader><DialogTitle>口座名を変更</DialogTitle></DialogHeader>
+          <DialogHeader><DialogTitle>口座を編集</DialogTitle></DialogHeader>
           <div className="space-y-4 pt-4">
-            <Input value={editAccountName} onChange={(e) => setEditAccountName(e.target.value)} className="rounded-xl" />
+            <Input value={editAccountName} onChange={(e) => setEditAccountName(e.target.value)} className="rounded-xl" placeholder="口座名" />
+            <Input type="number" value={editAccountBalance} onChange={(e) => setEditAccountBalance(e.target.value)} className="rounded-xl" placeholder="初期残高" />
+            <p className="text-xs text-muted-foreground">初期残高を変更すると現在の残高も変わります</p>
             <Button onClick={handleRenameAccount} disabled={!editAccountName.trim()} className="w-full rounded-xl">保存する</Button>
           </div>
         </DialogContent>


### PR DESCRIPTION
## Summary

- 口座編集ダイアログに初期残高（opening_balance）の入力フィールドを追加
- 編集ボタン押下時に現在の初期残高を初期値としてセット
- 保存時に名前と初期残高を同時に更新するよう修正

## 変更内容

**`src/app/settings/page.tsx`**
- `editAccountBalance` state を追加
- `handleRenameAccount` で `opening_balance` も一緒に更新
- 編集ボタンの `onClick` で `opening_balance` を初期値としてセット
- 編集ダイアログに初期残高フィールドと注記テキストを追加
- ダイアログタイトルを「口座名を変更」→「口座を編集」に変更

## Test plan

- [ ] 口座の編集ボタンを押したとき、現在の初期残高が入力欄にセットされている
- [ ] 初期残高を変更して保存すると、一覧の残高表示が更新される
- [ ] 口座名だけ変更して保存しても正常に動作する
- [ ] 初期残高に0や負の値を入れてもエラーにならない

🤖 Generated with [Claude Code](https://claude.com/claude-code)