### PR TITLE
feat: ダッシュボード・月次レポートのMonthSelectorをlgサイズに統一

### DIFF
--- a/src/app/monthly/page.tsx
+++ b/src/app/monthly/page.tsx
@@ -127,14 +127,12 @@ export default function MonthlyDetailsPage() {
           <p className="text-xs tracking-widest uppercase text-muted-foreground mb-2">
             Monthly Report
           </p>
-          <div className="flex items-end justify-between">
-            <h1 className="text-2xl font-medium tracking-tight text-foreground md:text-3xl">
-              {currentMonth}
-            </h1>
+          <div className="flex items-center justify-between">
             <MonthSelector
               month={currentMonth}
               onPrevious={() => setCurrentMonth(shiftMonth(currentMonth, -1))}
               onNext={() => setCurrentMonth(shiftMonth(currentMonth, 1))}
+              size="lg"
             />
           </div>
         </header>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -73,14 +73,12 @@ export default function DashboardPage() {
           <p className="text-xs tracking-widest uppercase text-muted-foreground mb-2">
             Overview
           </p>
-          <div className="flex items-end justify-between">
-            <h1 className="text-2xl font-medium tracking-tight text-foreground md:text-3xl">
-              {currentMonth}
-            </h1>
+          <div className="flex items-center justify-between">
             <MonthSelector
               month={currentMonth}
               onPrevious={() => setCurrentMonth(shiftMonth(currentMonth, -1))}
               onNext={() => setCurrentMonth(shiftMonth(currentMonth, 1))}
+              size="lg"
             />
           </div>
         </header>


### PR DESCRIPTION
## Summary

- `/`（Dashboard）と `/monthly` のヘッダー MonthSelector を transactions ページと同じ `size="lg"` に統一
- 月表示の `h1` テキストを削除し、MonthSelector を左側に配置するレイアウトに変更

## 変更内容

- `src/app/page.tsx` — ヘッダー構造を更新（`items-end` → `items-center`、h1 削除、MonthSelector `size="lg"` 追加）
- `src/app/monthly/page.tsx` — 同上

## Test plan

- [ ] `/` でヘッダーの月表示が lgサイズの MonthSelector になっていることを確認
- [ ] `/monthly` で同様の表示になっていることを確認
- [ ] 前後の月移動が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)