### PR TITLE
feat: 振替入力で送金元・振込先に自動で2件作成 (#15)

### DIFF
--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -71,84 +71,82 @@ export default function AddTransactionPage() {
     const { data: { user } } = await supabase.auth.getUser()
     if (!user) { setError("ログインが必要です"); setSaving(false); return }
 
-    if (isTransfer) {
-      // 振替カテゴリを取得。なければ自動作成
-      let transferCategoryId: string
-      const { data: existingCat } = await supabase
-        .from("categories")
-        .select("id")
-        .eq("type", "transfer")
-        .eq("user_id", user.id)
-        .single()
-      if (existingCat) {
-        transferCategoryId = existingCat.id
-      } else {
-        const { data: newCat, error: catError } = await supabase
+    try {
+      if (isTransfer) {
+        // 振替カテゴリを取得（.limit(1) で複数件でも安全）。なければ is_active=false で自動作成
+        const { data: existingCats, error: catFetchError } = await supabase
           .from("categories")
-          .insert({ user_id: user.id, name: "振替", type: "transfer", sort_order: 99 })
           .select("id")
-          .single()
-        if (catError || !newCat) { setError("保存に失敗しました"); setSaving(false); return }
-        transferCategoryId = newCat.id
-      }
+          .eq("type", "transfer")
+          .eq("user_id", user.id)
+          .limit(1)
+        if (catFetchError) throw catFetchError
 
-      const pairId = crypto.randomUUID()
-      const { error: insertError } = await supabase.from("transactions").insert([
-        {
+        let transferCategoryId: string
+        if (existingCats && existingCats.length > 0) {
+          transferCategoryId = existingCats[0].id
+        } else {
+          const { data: newCat, error: catError } = await supabase
+            .from("categories")
+            .insert({ user_id: user.id, name: "振替", type: "transfer", sort_order: 99, is_active: false })
+            .select("id")
+            .single()
+          if (catError || !newCat) throw catError
+          transferCategoryId = newCat.id
+        }
+
+        const pairId = crypto.randomUUID()
+        const { error: insertError } = await supabase.from("transactions").insert([
+          {
+            user_id: user.id,
+            type: "expense",
+            amount: parseInt(amount),
+            category_id: transferCategoryId,
+            account_id: selectedAccount,
+            txn_date: date,
+            name: name || null,
+            memo: memo || null,
+            transfer_pair_id: pairId,
+          },
+          {
+            user_id: user.id,
+            type: "income",
+            amount: parseInt(amount),
+            category_id: transferCategoryId,
+            account_id: toAccount,
+            txn_date: date,
+            name: name || null,
+            memo: memo || null,
+            transfer_pair_id: pairId,
+          },
+        ])
+        if (insertError) throw insertError
+      } else {
+        const { error: insertError } = await supabase.from("transactions").insert({
           user_id: user.id,
-          type: "expense",
+          type,
           amount: parseInt(amount),
-          category_id: transferCategoryId,
+          category_id: selectedCategory,
           account_id: selectedAccount,
           txn_date: date,
           name: name || null,
           memo: memo || null,
-          transfer_pair_id: pairId,
-        },
-        {
-          user_id: user.id,
-          type: "income",
-          amount: parseInt(amount),
-          category_id: transferCategoryId,
-          account_id: toAccount,
-          txn_date: date,
-          name: name || null,
-          memo: memo || null,
-          transfer_pair_id: pairId,
-        },
-      ])
-
-      if (insertError) {
-        setError("保存に失敗しました")
-        setSaving(false)
-        return
+        })
+        if (insertError) throw insertError
       }
-    } else {
-      const { error: insertError } = await supabase.from("transactions").insert({
-        user_id: user.id,
-        type,
-        amount: parseInt(amount),
-        category_id: selectedCategory,
-        account_id: selectedAccount,
-        txn_date: date,
-        name: name || null,
-        memo: memo || null,
-      })
 
-      if (insertError) {
-        setError("保存に失敗しました")
-        setSaving(false)
-        return
-      }
+      setAmount("")
+      setSelectedCategory("")
+      setToAccount("")
+      setName("")
+      setMemo("")
+      setDate(new Date().toISOString().split("T")[0])
+      router.push("/")
+    } catch {
+      setError("保存に失敗しました")
+    } finally {
+      setSaving(false)
     }
-
-    setAmount("")
-    setSelectedCategory("")
-    setToAccount("")
-    setName("")
-    setMemo("")
-    setDate(new Date().toISOString().split("T")[0])
-    router.push("/")
   }
 
   return (
@@ -176,7 +174,7 @@ export default function AddTransactionPage() {
                 onChange={(e) => handleAmountChange(e.target.value)}
                 className={cn(
                   "text-5xl md:text-6xl font-light tracking-tight text-center bg-transparent border-none outline-none w-full tabular-nums",
-                  type === "income" ? "text-income" : "text-foreground"
+                  type === "income" ? "text-income" : type === "transfer" ? "text-muted-foreground" : "text-foreground"
                 )}
                 placeholder="0"
               />

--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -242,7 +242,7 @@ export default function AddTransactionPage() {
                 {accounts.map((account) => (
                   <button
                     key={account.id}
-                    onClick={() => setSelectedAccount(account.id)}
+                    onClick={() => { setSelectedAccount(account.id); if (toAccount === account.id) setToAccount("") }}
                     className={cn(
                       "flex items-center gap-2 px-4 py-2.5 rounded-full text-sm transition-all",
                       selectedAccount === account.id

--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -72,13 +72,33 @@ export default function AddTransactionPage() {
     if (!user) { setError("ログインが必要です"); setSaving(false); return }
 
     if (isTransfer) {
+      // 振替カテゴリを取得。なければ自動作成
+      let transferCategoryId: string
+      const { data: existingCat } = await supabase
+        .from("categories")
+        .select("id")
+        .eq("type", "transfer")
+        .eq("user_id", user.id)
+        .single()
+      if (existingCat) {
+        transferCategoryId = existingCat.id
+      } else {
+        const { data: newCat, error: catError } = await supabase
+          .from("categories")
+          .insert({ user_id: user.id, name: "振替", type: "transfer", sort_order: 99 })
+          .select("id")
+          .single()
+        if (catError || !newCat) { setError("保存に失敗しました"); setSaving(false); return }
+        transferCategoryId = newCat.id
+      }
+
       const pairId = crypto.randomUUID()
       const { error: insertError } = await supabase.from("transactions").insert([
         {
           user_id: user.id,
           type: "expense",
           amount: parseInt(amount),
-          category_id: null,
+          category_id: transferCategoryId,
           account_id: selectedAccount,
           txn_date: date,
           name: name || null,
@@ -89,7 +109,7 @@ export default function AddTransactionPage() {
           user_id: user.id,
           type: "income",
           amount: parseInt(amount),
-          category_id: null,
+          category_id: transferCategoryId,
           account_id: toAccount,
           txn_date: date,
           name: name || null,

--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -19,6 +19,7 @@ export default function AddTransactionPage() {
   const [amount, setAmount] = useState("")
   const [selectedCategory, setSelectedCategory] = useState<string>("")
   const [selectedAccount, setSelectedAccount] = useState<string>("")
+  const [toAccount, setToAccount] = useState<string>("")
   const [date, setDate] = useState(new Date().toISOString().split("T")[0])
   const [name, setName] = useState("")
   const [memo, setMemo] = useState("")
@@ -38,6 +39,12 @@ export default function AddTransactionPage() {
 
   const filteredCategories = categories.filter((c) => c.type === type)
 
+  const handleTypeChange = (newType: TransactionType) => {
+    setType(newType)
+    setSelectedCategory("")
+    setToAccount("")
+  }
+
   const handleAmountChange = (value: string) => {
     setAmount(value.replace(/[^0-9]/g, ""))
   }
@@ -46,34 +53,78 @@ export default function AddTransactionPage() {
     ? new Intl.NumberFormat("ja-JP").format(parseInt(amount))
     : ""
 
+  const isTransfer = type === "transfer"
+
+  const isSubmitDisabled =
+    saving ||
+    !amount ||
+    amount === "0" ||
+    (!isTransfer && !selectedCategory) ||
+    !selectedAccount ||
+    (isTransfer && !toAccount)
+
   const handleSubmit = async () => {
-    if (!amount || amount === "0" || !selectedCategory || !selectedAccount) return
+    if (isSubmitDisabled) return
     setSaving(true)
     setError(null)
 
     const { data: { user } } = await supabase.auth.getUser()
     if (!user) { setError("ログインが必要です"); setSaving(false); return }
 
-    const { error: insertError } = await supabase.from("transactions").insert({
-      user_id: user.id,
-      type,
-      amount: parseInt(amount),
-      category_id: selectedCategory,
-      account_id: selectedAccount,
-      txn_date: date,
-      name: name || null,
-      memo: memo || null,
-    })
+    if (isTransfer) {
+      const pairId = crypto.randomUUID()
+      const { error: insertError } = await supabase.from("transactions").insert([
+        {
+          user_id: user.id,
+          type: "expense",
+          amount: parseInt(amount),
+          category_id: null,
+          account_id: selectedAccount,
+          txn_date: date,
+          name: name || null,
+          memo: memo || null,
+          transfer_pair_id: pairId,
+        },
+        {
+          user_id: user.id,
+          type: "income",
+          amount: parseInt(amount),
+          category_id: null,
+          account_id: toAccount,
+          txn_date: date,
+          name: name || null,
+          memo: memo || null,
+          transfer_pair_id: pairId,
+        },
+      ])
 
-    if (insertError) {
-      setError("保存に失敗しました")
-      setSaving(false)
-      return
+      if (insertError) {
+        setError("保存に失敗しました")
+        setSaving(false)
+        return
+      }
+    } else {
+      const { error: insertError } = await supabase.from("transactions").insert({
+        user_id: user.id,
+        type,
+        amount: parseInt(amount),
+        category_id: selectedCategory,
+        account_id: selectedAccount,
+        txn_date: date,
+        name: name || null,
+        memo: memo || null,
+      })
+
+      if (insertError) {
+        setError("保存に失敗しました")
+        setSaving(false)
+        return
+      }
     }
 
-    // フォームリセット
     setAmount("")
     setSelectedCategory("")
+    setToAccount("")
     setName("")
     setMemo("")
     setDate(new Date().toISOString().split("T")[0])
@@ -115,7 +166,7 @@ export default function AddTransactionPage() {
           {/* Type Toggle */}
           <div className="flex rounded-full bg-muted p-1">
             <button
-              onClick={() => { setType("expense"); setSelectedCategory("") }}
+              onClick={() => handleTypeChange("expense")}
               className={cn(
                 "flex-1 py-2.5 rounded-full text-sm transition-all",
                 type === "expense" ? "bg-card text-foreground shadow-sm" : "text-muted-foreground"
@@ -124,7 +175,7 @@ export default function AddTransactionPage() {
               支出
             </button>
             <button
-              onClick={() => { setType("income"); setSelectedCategory("") }}
+              onClick={() => handleTypeChange("income")}
               className={cn(
                 "flex-1 py-2.5 rounded-full text-sm transition-all",
                 type === "income" ? "bg-card text-foreground shadow-sm" : "text-muted-foreground"
@@ -132,44 +183,55 @@ export default function AddTransactionPage() {
             >
               収入
             </button>
+            <button
+              onClick={() => handleTypeChange("transfer")}
+              className={cn(
+                "flex-1 py-2.5 rounded-full text-sm transition-all",
+                type === "transfer" ? "bg-card text-foreground shadow-sm" : "text-muted-foreground"
+              )}
+            >
+              振替
+            </button>
           </div>
 
-          {/* Category Selection */}
-          <div>
-            <p className="text-xs tracking-wide uppercase text-muted-foreground mb-4">
-              カテゴリ
-            </p>
-            {filteredCategories.length === 0 ? (
-              <p className="text-sm text-muted-foreground">
-                カテゴリがありません。設定画面で追加してください。
+          {/* Category Selection (非表示 when transfer) */}
+          {!isTransfer && (
+            <div>
+              <p className="text-xs tracking-wide uppercase text-muted-foreground mb-4">
+                カテゴリ
               </p>
-            ) : (
-              <div className="grid grid-cols-4 gap-2">
-                {filteredCategories.map((category) => (
-                  <button
-                    key={category.id}
-                    onClick={() => setSelectedCategory(category.id)}
-                    className={cn(
-                      "flex flex-col items-center justify-center p-3 rounded-2xl transition-all",
-                      selectedCategory === category.id
-                        ? "bg-card ring-1 ring-border shadow-sm"
-                        : "hover:bg-muted/50"
-                    )}
-                  >
-                    <span className="text-xl mb-1.5">{category.icon}</span>
-                    <span className="text-[11px] text-muted-foreground truncate w-full text-center">
-                      {category.name}
-                    </span>
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
+              {filteredCategories.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  カテゴリがありません。設定画面で追加してください。
+                </p>
+              ) : (
+                <div className="grid grid-cols-4 gap-2">
+                  {filteredCategories.map((category) => (
+                    <button
+                      key={category.id}
+                      onClick={() => setSelectedCategory(category.id)}
+                      className={cn(
+                        "flex flex-col items-center justify-center p-3 rounded-2xl transition-all",
+                        selectedCategory === category.id
+                          ? "bg-card ring-1 ring-border shadow-sm"
+                          : "hover:bg-muted/50"
+                      )}
+                    >
+                      <span className="text-xl mb-1.5">{category.icon}</span>
+                      <span className="text-[11px] text-muted-foreground truncate w-full text-center">
+                        {category.name}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
 
           {/* Account Selection */}
           <div>
             <p className="text-xs tracking-wide uppercase text-muted-foreground mb-4">
-              口座
+              {isTransfer ? "送金元口座" : "口座"}
             </p>
             {accounts.length === 0 ? (
               <p className="text-sm text-muted-foreground">
@@ -195,6 +257,40 @@ export default function AddTransactionPage() {
               </div>
             )}
           </div>
+
+          {/* To Account Selection (transfer のみ) */}
+          {isTransfer && (
+            <div>
+              <p className="text-xs tracking-wide uppercase text-muted-foreground mb-4">
+                振込先口座
+              </p>
+              {accounts.length <= 1 ? (
+                <p className="text-sm text-muted-foreground">
+                  振替には2つ以上の口座が必要です。<Link href="/settings?tab=accounts" className="underline underline-offset-2 hover:text-foreground transition-colors">設定画面で追加</Link>してください。
+                </p>
+              ) : (
+                <div className="flex flex-wrap gap-2">
+                  {accounts
+                    .filter((account) => account.id !== selectedAccount)
+                    .map((account) => (
+                      <button
+                        key={account.id}
+                        onClick={() => setToAccount(account.id)}
+                        className={cn(
+                          "flex items-center gap-2 px-4 py-2.5 rounded-full text-sm transition-all",
+                          toAccount === account.id
+                            ? "bg-card ring-1 ring-border shadow-sm text-foreground"
+                            : "text-muted-foreground hover:bg-muted/50"
+                        )}
+                      >
+                        <span className="text-base">{account.icon}</span>
+                        {account.name}
+                      </button>
+                    ))}
+                </div>
+              )}
+            </div>
+          )}
 
           {/* Name */}
           <div>
@@ -244,7 +340,7 @@ export default function AddTransactionPage() {
           {/* Submit Button */}
           <Button
             onClick={handleSubmit}
-            disabled={saving || !amount || amount === "0" || !selectedCategory || !selectedAccount}
+            disabled={isSubmitDisabled}
             className="w-full h-14 rounded-full text-base"
           >
             {saving ? "保存中..." : "保存する"}


### PR DESCRIPTION
## Summary
- `/add` の入力タイプに「振替」タブを追加
- 振替選択時：カテゴリ非表示・送金元口座＋振込先口座のUI表示
- 保存時に `transfer_pair_id` を共有した expense/income の2レコードを一括 insert
- 振替カテゴリ（type=transfer）を自動取得/作成して `category_id NOT NULL` 制約をクリア

## バグ修正（レビュー中に発見・修正）
1. 送金元変更時に振込先が同じ口座になるバグ → 送金元変更時に `toAccount` をリセット
2. `category_id NOT NULL` 制約エラー → transfer カテゴリを取得/自動作成して渡す

## 変更ファイル
- `src/app/add/page.tsx` のみ

## 動作確認
- Playwright e2e で楽天銀行 → テスト現金 ¥5,000 の振替保存 → 明細に2件（支出・収入ペア）確認済み

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)