### PR TITLE
feat: クレカ引き落とし一括振替機能を追加

### DIFF
--- a/src/app/monthly/page.tsx
+++ b/src/app/monthly/page.tsx
@@ -7,6 +7,7 @@ import { MonthSelector } from "@/components/month-selector"
 import { formatCurrency, getTransactions, getAccounts, getCategories, getTemplates, getCurrentMonth, shiftMonth } from "@/lib/data"
 import { Transaction, Account, Category, RecurringTemplate } from "@/lib/types"
 import { cn } from "@/lib/utils"
+import { supabase } from "@/lib/supabase"
 
 const INVESTMENT_CATEGORIES = new Set(["投資"])
 
@@ -62,6 +63,7 @@ export default function MonthlyDetailsPage() {
   const [categories, setCategories] = useState<Category[]>([])
   const [templates, setTemplates] = useState<RecurringTemplate[]>([])
   const [loading, setLoading] = useState(true)
+  const [debitTransferring, setDebitTransferring] = useState<string | null>(null)
 
   useEffect(() => {
     setLoading(true)
@@ -77,6 +79,71 @@ export default function MonthlyDetailsPage() {
       setTemplates(tpls)
     }).finally(() => setLoading(false))
   }, [currentMonth])
+
+  async function handleDebitTransfer(creditAccount: Account) {
+    if (!creditAccount.debit_account_id || creditAccount.balance >= 0) return
+    setDebitTransferring(creditAccount.id)
+    try {
+      const { data: { user } } = await supabase.auth.getUser()
+      if (!user) return
+
+      const { data: existingCats, error: catFetchError } = await supabase
+        .from("categories")
+        .select("id")
+        .eq("type", "transfer")
+        .eq("user_id", user.id)
+        .limit(1)
+      if (catFetchError) throw catFetchError
+
+      let transferCategoryId: string
+      if (existingCats && existingCats.length > 0) {
+        transferCategoryId = existingCats[0].id
+      } else {
+        const { data: newCat, error: catError } = await supabase
+          .from("categories")
+          .insert({ user_id: user.id, name: "振替", type: "transfer", sort_order: 99, is_active: false })
+          .select("id")
+          .single()
+        if (catError || !newCat) throw catError
+        transferCategoryId = newCat.id
+      }
+
+      const amount = Math.abs(creditAccount.balance)
+      const today = new Date().toISOString().split("T")[0]
+      const pairId = crypto.randomUUID()
+
+      const { error } = await supabase.from("transactions").insert([
+        {
+          user_id: user.id,
+          type: "expense",
+          amount,
+          category_id: transferCategoryId,
+          account_id: creditAccount.debit_account_id,
+          txn_date: today,
+          memo: `${creditAccount.name} 引き落とし`,
+          transfer_pair_id: pairId,
+        },
+        {
+          user_id: user.id,
+          type: "income",
+          amount,
+          category_id: transferCategoryId,
+          account_id: creditAccount.id,
+          txn_date: today,
+          memo: `${creditAccount.name} 引き落とし`,
+          transfer_pair_id: pairId,
+        },
+      ])
+      if (error) throw error
+
+      const updated = await getAccounts()
+      setAccounts(updated)
+    } catch {
+      alert("引き落とし処理に失敗しました")
+    } finally {
+      setDebitTransferring(null)
+    }
+  }
 
   const monthlyBreakdown = useMemo(() => {
     // 固定費カテゴリIDの判定:
@@ -247,9 +314,20 @@ export default function MonthlyDetailsPage() {
                             <span className="text-base">{account.icon}</span>
                             <span className="text-sm text-muted-foreground">{account.name}</span>
                           </div>
-                          <span className="text-sm tabular-nums text-foreground">
-                            {formatCurrency(account.balance)}
-                          </span>
+                          <div className="flex items-center gap-3">
+                            <span className={cn("text-sm tabular-nums", account.balance < 0 ? "text-expense" : "text-foreground")}>
+                              {formatCurrency(account.balance)}
+                            </span>
+                            {account.kind === "credit_card" && account.debit_account_id && account.balance < 0 && (
+                              <button
+                                onClick={() => handleDebitTransfer(account)}
+                                disabled={debitTransferring === account.id}
+                                className="text-xs px-3 py-1 rounded-full bg-primary/10 text-primary hover:bg-primary/20 transition-colors disabled:opacity-50"
+                              >
+                                {debitTransferring === account.id ? "処理中..." : "引き落とし"}
+                              </button>
+                            )}
+                          </div>
                         </div>
                       ))}
                     </div>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -55,12 +55,14 @@ export default function SettingsPage() {
   const [newAccountName, setNewAccountName] = useState("")
   const [newAccountKind, setNewAccountKind] = useState<"bank" | "cash" | "credit_card" | "e_money">("bank")
   const [newAccountBalance, setNewAccountBalance] = useState("")
+  const [newAccountDebitId, setNewAccountDebitId] = useState("")
   const [addAccountOpen, setAddAccountOpen] = useState(false)
 
   // 口座編集
   const [editingAccount, setEditingAccount] = useState<Account | null>(null)
   const [editAccountName, setEditAccountName] = useState("")
   const [editAccountBalance, setEditAccountBalance] = useState("")
+  const [editAccountDebitId, setEditAccountDebitId] = useState("")
 
   // テンプレート編集
   const [editingTemplate, setEditingTemplate] = useState<RecurringTemplate | null>(null)
@@ -159,10 +161,12 @@ export default function SettingsPage() {
       opening_balance: parseInt(newAccountBalance) || 0,
       sort_order: 99,
       is_active: true,
+      debit_account_id: newAccountKind === "credit_card" && newAccountDebitId ? newAccountDebitId : null,
     })
     if (error) { alert("追加に失敗しました"); return }
     setNewAccountName("")
     setNewAccountBalance("")
+    setNewAccountDebitId("")
     setAddAccountOpen(false)
     loadData()
   }
@@ -173,6 +177,7 @@ export default function SettingsPage() {
     const { error } = await supabase.from("accounts").update({
       name: editAccountName.trim(),
       opening_balance: parseInt(editAccountBalance) || 0,
+      debit_account_id: editingAccount.kind === "credit_card" && editAccountDebitId ? editAccountDebitId : null,
     }).eq("id", editingAccount.id)
     if (error) { alert("変更に失敗しました"); return }
     setEditingAccount(null)
@@ -422,7 +427,7 @@ export default function SettingsPage() {
                       <DialogHeader><DialogTitle>口座を追加</DialogTitle></DialogHeader>
                       <div className="space-y-4 pt-4">
                         <Input placeholder="口座名" value={newAccountName} onChange={(e) => setNewAccountName(e.target.value)} className="rounded-xl" />
-                        <Select value={newAccountKind} onValueChange={(v) => setNewAccountKind(v as typeof newAccountKind)}>
+                        <Select value={newAccountKind} onValueChange={(v) => { setNewAccountKind(v as typeof newAccountKind); setNewAccountDebitId("") }}>
                           <SelectTrigger className="rounded-xl"><SelectValue placeholder="種類" /></SelectTrigger>
                           <SelectContent>
                             <SelectItem value="bank">銀行口座</SelectItem>
@@ -431,6 +436,16 @@ export default function SettingsPage() {
                             <SelectItem value="e_money">電子マネー</SelectItem>
                           </SelectContent>
                         </Select>
+                        {newAccountKind === "credit_card" && (
+                          <Select value={newAccountDebitId} onValueChange={setNewAccountDebitId}>
+                            <SelectTrigger className="rounded-xl"><SelectValue placeholder="引き落とし元口座（任意）" /></SelectTrigger>
+                            <SelectContent>
+                              {accounts.filter((a) => a.kind === "bank").map((a) => (
+                                <SelectItem key={a.id} value={a.id}>{a.icon} {a.name}</SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        )}
                         <Input type="number" placeholder="初期残高（任意）" value={newAccountBalance} onChange={(e) => setNewAccountBalance(e.target.value)} className="rounded-xl" />
                         <Button onClick={handleAddAccount} className="w-full rounded-xl">追加する</Button>
                       </div>
@@ -453,7 +468,7 @@ export default function SettingsPage() {
                         </div>
                         <div className="flex items-center gap-1">
                           <button
-                            onClick={() => { setEditingAccount(account); setEditAccountName(account.name); setEditAccountBalance(String(account.opening_balance ?? 0)) }}
+                            onClick={() => { setEditingAccount(account); setEditAccountName(account.name); setEditAccountBalance(String(account.opening_balance ?? 0)); setEditAccountDebitId(account.debit_account_id ?? "") }}
                             className="p-2 text-muted-foreground hover:text-foreground transition-colors"
                           >
                             <Pencil className="h-4 w-4" />
@@ -600,6 +615,16 @@ export default function SettingsPage() {
           <DialogHeader><DialogTitle>口座を編集</DialogTitle></DialogHeader>
           <div className="space-y-4 pt-4">
             <Input value={editAccountName} onChange={(e) => setEditAccountName(e.target.value)} className="rounded-xl" placeholder="口座名" />
+            {editingAccount?.kind === "credit_card" && (
+              <Select value={editAccountDebitId} onValueChange={setEditAccountDebitId}>
+                <SelectTrigger className="rounded-xl"><SelectValue placeholder="引き落とし元口座（任意）" /></SelectTrigger>
+                <SelectContent>
+                  {accounts.filter((a) => a.kind === "bank").map((a) => (
+                    <SelectItem key={a.id} value={a.id}>{a.icon} {a.name}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
             <Input type="number" value={editAccountBalance} onChange={(e) => setEditAccountBalance(e.target.value)} className="rounded-xl" placeholder="初期残高" />
             <p className="text-xs text-muted-foreground">初期残高を変更すると現在の残高も変わります</p>
             <Button onClick={handleRenameAccount} disabled={!editAccountName.trim()} className="w-full rounded-xl">保存する</Button>

--- a/src/lib/data/index.ts
+++ b/src/lib/data/index.ts
@@ -59,7 +59,7 @@ export async function getCategories(): Promise<Category[]> {
 export async function getAccounts(): Promise<Account[]> {
   const { data: accountsData, error } = await supabase
     .from("accounts")
-    .select("id, name, kind, opening_balance")
+    .select("id, name, kind, opening_balance, debit_account_id")
     .eq("is_active", true)
     .order("sort_order")
     .order("name")
@@ -87,6 +87,7 @@ export async function getAccounts(): Promise<Account[]> {
     opening_balance: Number(row.opening_balance),
     balance: Number(row.opening_balance) + (balanceMap[row.id] ?? 0),
     icon: ACCOUNT_ICONS[row.kind] ?? "🏦",
+    debit_account_id: row.debit_account_id ?? null,
   }))
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -29,6 +29,7 @@ export interface Account {
   opening_balance: number
   balance: number     // opening_balance + 累積入出金
   icon: string
+  debit_account_id?: string | null
 }
 
 export interface RecurringTemplate {

--- a/supabase/migrations/20260502000001_add_debit_account_to_accounts.sql
+++ b/supabase/migrations/20260502000001_add_debit_account_to_accounts.sql
@@ -1,0 +1,2 @@
+alter table accounts
+  add column debit_account_id uuid references accounts(id) on delete set null;


### PR DESCRIPTION
## Summary

- クレカ口座に「引き落とし元口座（銀行）」を設定できるようにした
- 月次ページでクレカ残高がマイナスのとき「引き落とし」ボタンを表示
- ボタン1タップで銀行→クレカへの振替を自動生成し、二重計上を解消

## 変更内容

**DB**
- `accounts` テーブルに `debit_account_id uuid` カラムを追加（`20260502000001`）

**型定義・データ層**
- `Account` 型に `debit_account_id?: string | null` を追加
- `getAccounts()` で `debit_account_id` を取得するよう更新

**設定ページ (`src/app/settings/page.tsx`)**
- 口座追加ダイアログ：クレジットカード選択時に「引き落とし元口座（任意）」セレクトを表示
- 口座編集ダイアログ：クレカ口座のとき同セレクトを表示

**月次ページ (`src/app/monthly/page.tsx`)**
- クレカ口座の残高がマイナス かつ `debit_account_id` 設定済みのとき「引き落とし」ボタンを表示
- `handleDebitTransfer()`：振替トランザクションを自動生成、処理後に残高を即時更新

## Test plan

- [x] 設定ページでクレカ口座の編集ダイアログに「引き落とし元口座」セレクトが表示される
- [x] 銀行口座のみが選択肢に出る
- [x] 月次ページでクレカ残高がマイナスのとき「引き落とし」ボタンが表示される
- [x] ボタン押下で銀行残高が減り、クレカ残高が¥0になる
- [x] 「引き落とし」ボタンが消える（残高¥0のため）
- [x] 振替なので月次の支出合計は変わらない

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)