### PR TITLE
fix: 振替を月次集計から除外・引き落とし残高を月別計算・UI即時更新を修正

### DIFF
--- a/src/app/monthly/page.tsx
+++ b/src/app/monthly/page.tsx
@@ -65,11 +65,20 @@ export default function MonthlyDetailsPage() {
   const [loading, setLoading] = useState(true)
   const [debitTransferring, setDebitTransferring] = useState<string | null>(null)
 
+  const untilDate = useMemo(() => {
+    const match = currentMonth.match(/(\d{4})年(\d{1,2})月/)
+    if (!match) return undefined
+    const y = parseInt(match[1]), m = parseInt(match[2])
+    const lastDay = new Date(y, m, 0).getDate()
+    return `${y}-${String(m).padStart(2, "0")}-${String(lastDay).padStart(2, "0")}`
+  }, [currentMonth])
+
   useEffect(() => {
     setLoading(true)
     Promise.all([
       getTransactions(currentMonth),
-      getAccounts(),
+      getAccounts(untilDate),
+
       getCategories(),
       getTemplates(),
     ]).then(([txs, accs, cats, tpls]) => {
@@ -81,7 +90,11 @@ export default function MonthlyDetailsPage() {
   }, [currentMonth])
 
   async function handleDebitTransfer(creditAccount: Account) {
-    if (!creditAccount.debit_account_id || creditAccount.balance >= 0) return
+    if (!creditAccount.debit_account_id) return
+    const amount = transactions
+      .filter((t) => t.account_id === creditAccount.id && t.type === "expense")
+      .reduce((sum, t) => sum + t.amount, 0)
+    if (amount === 0) return
     setDebitTransferring(creditAccount.id)
     try {
       const { data: { user } } = await supabase.auth.getUser()
@@ -107,9 +120,7 @@ export default function MonthlyDetailsPage() {
         if (catError || !newCat) throw catError
         transferCategoryId = newCat.id
       }
-
-      const amount = Math.abs(creditAccount.balance)
-      const today = new Date().toISOString().split("T")[0]
+      const txnDate = untilDate ?? new Date().toISOString().split("T")[0]
       const pairId = crypto.randomUUID()
 
       const { error } = await supabase.from("transactions").insert([
@@ -119,7 +130,7 @@ export default function MonthlyDetailsPage() {
           amount,
           category_id: transferCategoryId,
           account_id: creditAccount.debit_account_id,
-          txn_date: today,
+          txn_date: txnDate,
           memo: `${creditAccount.name} 引き落とし`,
           transfer_pair_id: pairId,
         },
@@ -129,15 +140,19 @@ export default function MonthlyDetailsPage() {
           amount,
           category_id: transferCategoryId,
           account_id: creditAccount.id,
-          txn_date: today,
+          txn_date: txnDate,
           memo: `${creditAccount.name} 引き落とし`,
           transfer_pair_id: pairId,
         },
       ])
       if (error) throw error
 
-      const updated = await getAccounts()
-      setAccounts(updated)
+      const [updatedAccounts, updatedTxs] = await Promise.all([
+        getAccounts(untilDate),
+        getTransactions(currentMonth),
+      ])
+      setAccounts(updatedAccounts)
+      setTransactions(updatedTxs)
     } catch {
       alert("引き落とし処理に失敗しました")
     } finally {
@@ -162,8 +177,8 @@ export default function MonthlyDetailsPage() {
       return Object.entries(grouped).map(([name, amount]) => ({ name, amount }))
     }
 
-    const incomeTxs = transactions.filter((t) => t.type === "income")
-    const expenseTxs = transactions.filter((t) => t.type === "expense")
+    const incomeTxs = transactions.filter((t) => t.type === "income" && !t.transfer_pair_id)
+    const expenseTxs = transactions.filter((t) => t.type === "expense" && !t.transfer_pair_id)
     const investmentTxs = expenseTxs.filter((t) => INVESTMENT_CATEGORIES.has(t.category))
     const fixedTxs = expenseTxs.filter((t) => fixedCategoryIds.has(t.category_id))
     const variableTxs = expenseTxs.filter(
@@ -192,6 +207,23 @@ export default function MonthlyDetailsPage() {
 
   const totalExpense = monthlyBreakdown.fixedExpenses.total + monthlyBreakdown.variableExpenses.total
   const balance = monthlyBreakdown.income.total - totalExpense - monthlyBreakdown.investments.total
+
+  // クレカの未引き落とし額: expense合計 - 振替income合計
+  const monthlyUnpaidByAccount = useMemo(() => {
+    const expense: Record<string, number> = {}
+    const transferIncome: Record<string, number> = {}
+    for (const t of transactions) {
+      if (t.type === "expense" && !t.transfer_pair_id)
+        expense[t.account_id] = (expense[t.account_id] || 0) + t.amount
+      if (t.type === "income" && t.transfer_pair_id)
+        transferIncome[t.account_id] = (transferIncome[t.account_id] || 0) + t.amount
+    }
+    const result: Record<string, number> = {}
+    for (const id of new Set([...Object.keys(expense), ...Object.keys(transferIncome)])) {
+      result[id] = (expense[id] ?? 0) - (transferIncome[id] ?? 0)
+    }
+    return result
+  }, [transactions])
 
   const accountsByKind = useMemo(() => {
     const grouped: Record<string, { accounts: Account[]; total: number }> = {}
@@ -318,7 +350,7 @@ export default function MonthlyDetailsPage() {
                             <span className={cn("text-sm tabular-nums", account.balance < 0 ? "text-expense" : "text-foreground")}>
                               {formatCurrency(account.balance)}
                             </span>
-                            {account.kind === "credit_card" && account.debit_account_id && account.balance < 0 && (
+                            {account.kind === "credit_card" && account.debit_account_id && (monthlyUnpaidByAccount[account.id] ?? 0) > 0 && (
                               <button
                                 onClick={() => handleDebitTransfer(account)}
                                 disabled={debitTransferring === account.id}

--- a/src/lib/data/index.ts
+++ b/src/lib/data/index.ts
@@ -56,7 +56,7 @@ export async function getCategories(): Promise<Category[]> {
   }))
 }
 
-export async function getAccounts(): Promise<Account[]> {
+export async function getAccounts(untilDate?: string): Promise<Account[]> {
   const { data: accountsData, error } = await supabase
     .from("accounts")
     .select("id, name, kind, opening_balance, debit_account_id")
@@ -66,10 +66,10 @@ export async function getAccounts(): Promise<Account[]> {
 
   if (error) throw error
 
-  // 口座ごとの累積入出金を一括取得
-  const { data: txData, error: txError } = await supabase
-    .from("transactions")
-    .select("account_id, type, amount")
+  // 口座ごとの累積入出金を一括取得（untilDate指定時はその日以前のみ）
+  let txQuery = supabase.from("transactions").select("account_id, type, amount")
+  if (untilDate) txQuery = txQuery.lte("txn_date", untilDate)
+  const { data: txData, error: txError } = await txQuery
 
   if (txError) throw txError
 
@@ -97,7 +97,8 @@ export async function getTransactions(month?: string): Promise<Transaction[]> {
     .select(`
       id, type, amount, txn_date, name, memo,
       category_id, categories(name),
-      account_id, accounts(name)
+      account_id, accounts(name),
+      transfer_pair_id
     `)
     .order("txn_date", { ascending: false })
     .order("created_at", { ascending: false })
@@ -132,6 +133,7 @@ export async function getTransactions(month?: string): Promise<Transaction[]> {
       name: row.name ?? undefined,
       memo: row.memo ?? undefined,
       icon: CATEGORY_ICONS[categoryName] ?? "📦",
+      transfer_pair_id: row.transfer_pair_id ?? null,
     }
   })
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -12,6 +12,7 @@ export interface Transaction {
   name?: string       // 品目名（任意）
   memo?: string
   icon?: string       // カテゴリアイコン（静的マッピング）
+  transfer_pair_id?: string | null
 }
 
 export interface Category {


### PR DESCRIPTION
## Summary

- 振替トランザクション（transfer_pair_id 付き）が収入・支出の月次集計に混入するバグを修正
- 月次ページの口座残高を選択月の月末時点の値に修正（全期間累積から変更）
- 引き落としボタン押下後に UI が即時更新されないバグを修正

## 変更内容

**型・データ層**
- `Transaction` 型に `transfer_pair_id` を追加
- `getTransactions` で `transfer_pair_id` を取得
- `getAccounts(untilDate?)` で月末日までの残高計算に対応

**月次ページ (`monthly/page.tsx`)**
- `untilDate`（月末日）を useMemo で算出し、口座残高・引き落とし日付に使用
- 月次集計（収入/支出）から `transfer_pair_id` 付きを除外
- 未引き落とし額（当月 expense - 振替 income）で引き落としボタン表示条件を管理
- 引き落とし後に `accounts` と `transactions` の両方を再取得して UI を即時反映

## Test plan

- [ ] 月次ページで過去月を表示したとき、口座残高がその月末時点の値になっている
- [ ] 引き落としボタンを押すと、クレカ残高が ¥0 になりボタンが消える
- [ ] 引き落とし後、収入・変動費セクションに「振替」が混入しない
- [ ] 引き落とし済みの月に戻ったとき、ボタンが表示されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)