### PR TITLE
fix: 振替の集計混入・ペア不整合を修正、PWAアセット認証除外と削除確認を追加

### DIFF
--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -7,7 +7,7 @@ import { AppLayout } from "@/components/app-layout"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
-import { getCategories, getAccounts } from "@/lib/data"
+import { getCategories, getAccounts, getOrCreateTransferCategory } from "@/lib/data"
 import { Category, Account, TransactionType } from "@/lib/types"
 import { supabase } from "@/lib/supabase"
 import { cn } from "@/lib/utils"
@@ -73,28 +73,7 @@ export default function AddTransactionPage() {
 
     try {
       if (isTransfer) {
-        // 振替カテゴリを取得（.limit(1) で複数件でも安全）。なければ is_active=false で自動作成
-        const { data: existingCats, error: catFetchError } = await supabase
-          .from("categories")
-          .select("id")
-          .eq("type", "transfer")
-          .eq("user_id", user.id)
-          .limit(1)
-        if (catFetchError) throw catFetchError
-
-        let transferCategoryId: string
-        if (existingCats && existingCats.length > 0) {
-          transferCategoryId = existingCats[0].id
-        } else {
-          const { data: newCat, error: catError } = await supabase
-            .from("categories")
-            .insert({ user_id: user.id, name: "振替", type: "transfer", sort_order: 99, is_active: false })
-            .select("id")
-            .single()
-          if (catError || !newCat) throw catError
-          transferCategoryId = newCat.id
-        }
-
+        const transferCategoryId = await getOrCreateTransferCategory(user.id)
         const pairId = crypto.randomUUID()
         const { error: insertError } = await supabase.from("transactions").insert([
           {

--- a/src/app/monthly/page.tsx
+++ b/src/app/monthly/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useMemo } from "react"
 import Link from "next/link"
 import { AppLayout } from "@/components/app-layout"
 import { MonthSelector } from "@/components/month-selector"
-import { formatCurrency, getTransactions, getAccounts, getCategories, getTemplates, getCurrentMonth, shiftMonth } from "@/lib/data"
+import { formatCurrency, getTransactions, getAccounts, getCategories, getTemplates, getCurrentMonth, shiftMonth, getOrCreateTransferCategory } from "@/lib/data"
 import { Transaction, Account, Category, RecurringTemplate } from "@/lib/types"
 import { cn } from "@/lib/utils"
 import { supabase } from "@/lib/supabase"
@@ -91,8 +91,9 @@ export default function MonthlyDetailsPage() {
 
   async function handleDebitTransfer(creditAccount: Account) {
     if (!creditAccount.debit_account_id) return
+    // transfer_pair_id 付きの expense（カードからの振替）は除外して二重計上を防ぐ
     const amount = transactions
-      .filter((t) => t.account_id === creditAccount.id && t.type === "expense")
+      .filter((t) => t.account_id === creditAccount.id && t.type === "expense" && !t.transfer_pair_id)
       .reduce((sum, t) => sum + t.amount, 0)
     if (amount === 0) return
     setDebitTransferring(creditAccount.id)
@@ -100,26 +101,7 @@ export default function MonthlyDetailsPage() {
       const { data: { user } } = await supabase.auth.getUser()
       if (!user) return
 
-      const { data: existingCats, error: catFetchError } = await supabase
-        .from("categories")
-        .select("id")
-        .eq("type", "transfer")
-        .eq("user_id", user.id)
-        .limit(1)
-      if (catFetchError) throw catFetchError
-
-      let transferCategoryId: string
-      if (existingCats && existingCats.length > 0) {
-        transferCategoryId = existingCats[0].id
-      } else {
-        const { data: newCat, error: catError } = await supabase
-          .from("categories")
-          .insert({ user_id: user.id, name: "振替", type: "transfer", sort_order: 99, is_active: false })
-          .select("id")
-          .single()
-        if (catError || !newCat) throw catError
-        transferCategoryId = newCat.id
-      }
+      const transferCategoryId = await getOrCreateTransferCategory(user.id)
       const txnDate = untilDate ?? new Date().toISOString().split("T")[0]
       const pairId = crypto.randomUUID()
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,7 @@ import { MonthSelector } from "@/components/month-selector"
 import { SummaryCard } from "@/components/summary-card"
 import { CategoryChart } from "@/components/category-chart"
 import { RecentTransactions } from "@/components/recent-transactions"
-import { getTransactions, getCurrentMonth } from "@/lib/data"
+import { getTransactions, getCurrentMonth, shiftMonth } from "@/lib/data"
 import { Transaction } from "@/lib/types"
 
 const CHART_COLORS = [
@@ -18,12 +18,6 @@ const CHART_COLORS = [
   "var(--color-muted-foreground)",
 ]
 
-function shiftMonth(month: string, delta: number): string {
-  const match = month.match(/(\d{4})年(\d{1,2})月/)
-  if (!match) return month
-  const date = new Date(parseInt(match[1]), parseInt(match[2]) - 1 + delta)
-  return `${date.getFullYear()}年${date.getMonth() + 1}月`
-}
 
 export default function DashboardPage() {
   const [currentMonth, setCurrentMonth] = useState(getCurrentMonth())
@@ -38,17 +32,18 @@ export default function DashboardPage() {
   }, [currentMonth])
 
   const monthlyData = useMemo(() => {
-    const income = transactions
+    const nonTransfer = transactions.filter((t) => !t.transfer_pair_id)
+    const income = nonTransfer
       .filter((t) => t.type === "income")
       .reduce((s, t) => s + t.amount, 0)
-    const expense = transactions
+    const expense = nonTransfer
       .filter((t) => t.type === "expense")
       .reduce((s, t) => s + t.amount, 0)
     const balance = income - expense
     const savingsRate = income > 0 ? Math.round(((income - expense) / income) * 1000) / 10 : 0
 
     const categoryMap: Record<string, number> = {}
-    for (const t of transactions.filter((t) => t.type === "expense")) {
+    for (const t of nonTransfer.filter((t) => t.type === "expense")) {
       categoryMap[t.category] = (categoryMap[t.category] ?? 0) + t.amount
     }
     const sorted = Object.entries(categoryMap).sort((a, b) => b[1] - a[1])

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -83,6 +83,9 @@ export default function SettingsPage() {
   const [addTplOpen, setAddTplOpen] = useState(false)
   const [applyingTemplates, setApplyingTemplates] = useState(false)
 
+  // 削除確認用
+  const [deletingItem, setDeletingItem] = useState<{ kind: "category" | "account" | "template"; id: string; name: string } | null>(null)
+
   async function loadData() {
     setLoading(true)
     const [cats, accs, tpls] = await Promise.all([getCategories(), getAccounts(), getTemplates()])
@@ -236,6 +239,26 @@ export default function SettingsPage() {
     loadData()
   }
 
+  // 削除確認ダイアログからの実行
+  async function handleConfirmDelete() {
+    if (!deletingItem) return
+    const { kind, id } = deletingItem
+    let error = null
+    if (kind === "category") {
+      const result = await supabase.from("categories").update({ is_active: false }).eq("id", id)
+      error = result.error
+    } else if (kind === "account") {
+      const result = await supabase.from("accounts").update({ is_active: false }).eq("id", id)
+      error = result.error
+    } else {
+      const result = await supabase.from("recurring_templates").update({ is_active: false }).eq("id", id)
+      error = result.error
+    }
+    if (error) { alert("削除に失敗しました"); return }
+    setDeletingItem(null)
+    loadData()
+  }
+
   // 今月分を一括登録
   async function handleApplyTemplates() {
     if (templates.length === 0) return
@@ -308,7 +331,7 @@ export default function SettingsPage() {
                 <Pencil className="h-4 w-4" />
               </button>
               <button
-                onClick={() => handleDeleteCategory(category.id)}
+                onClick={() => setDeletingItem({ kind: "category", id: category.id, name: category.name })}
                 className="p-2 text-muted-foreground hover:text-destructive transition-colors"
               >
                 <Trash2 className="h-4 w-4" />
@@ -474,7 +497,7 @@ export default function SettingsPage() {
                             <Pencil className="h-4 w-4" />
                           </button>
                           <button
-                            onClick={() => handleDeleteAccount(account.id)}
+                            onClick={() => setDeletingItem({ kind: "account", id: account.id, name: account.name })}
                             className="p-2 text-muted-foreground hover:text-destructive transition-colors"
                           >
                             <Trash2 className="h-4 w-4" />
@@ -569,7 +592,7 @@ export default function SettingsPage() {
                               <Pencil className="h-4 w-4" />
                             </button>
                             <button
-                              onClick={() => handleDeleteTemplate(tpl.id)}
+                              onClick={() => setDeletingItem({ kind: "template", id: tpl.id, name: tpl.name })}
                               className="p-2 text-muted-foreground hover:text-destructive transition-colors"
                             >
                               <Trash2 className="h-4 w-4" />
@@ -628,6 +651,28 @@ export default function SettingsPage() {
             <Input type="number" value={editAccountBalance} onChange={(e) => setEditAccountBalance(e.target.value)} className="rounded-xl" placeholder="初期残高" />
             <p className="text-xs text-muted-foreground">初期残高を変更すると現在の残高も変わります</p>
             <Button onClick={handleRenameAccount} disabled={!editAccountName.trim()} className="w-full rounded-xl">保存する</Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* 削除確認 Dialog */}
+      <Dialog open={!!deletingItem} onOpenChange={(o) => { if (!o) setDeletingItem(null) }}>
+        <DialogContent className="rounded-2xl max-w-sm">
+          <DialogHeader>
+            <DialogTitle>
+              {deletingItem?.kind === "category" ? "カテゴリを削除" : deletingItem?.kind === "account" ? "口座を削除" : "固定費を削除"}
+            </DialogTitle>
+          </DialogHeader>
+          <div className="space-y-5 pt-2">
+            <p className="text-sm text-muted-foreground">「{deletingItem?.name}」を削除します。元に戻せません。</p>
+            <div className="flex gap-3">
+              <Button variant="outline" className="flex-1 rounded-xl" onClick={() => setDeletingItem(null)}>
+                キャンセル
+              </Button>
+              <Button variant="destructive" className="flex-1 rounded-xl" onClick={handleConfirmDelete}>
+                削除する
+              </Button>
+            </div>
           </div>
         </DialogContent>
       </Dialog>

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -89,17 +89,33 @@ export default function TransactionsPage() {
   }
 
   async function handleUpdate() {
-    if (!editingTx || !editAmount || !editCategoryId || !editAccountId) return
+    if (!editingTx || !editAmount) return
+    const isTransfer = !!editingTx.transfer_pair_id
+    if (!isTransfer && (!editCategoryId || !editAccountId)) return
     setSaving(true)
-    const { error } = await supabase.from("transactions").update({
-      type: editType,
-      amount: parseInt(editAmount),
-      category_id: editCategoryId,
-      account_id: editAccountId,
-      txn_date: editDate,
-      name: editName || null,
-      memo: editMemo || null,
-    }).eq("id", editingTx.id)
+
+    let error
+    if (isTransfer) {
+      // ペア両方に金額・日付・品目名・メモのみ反映（type, category_id, account_id は変更しない）
+      const { error: pairError } = await supabase.from("transactions").update({
+        amount: parseInt(editAmount),
+        txn_date: editDate,
+        name: editName || null,
+        memo: editMemo || null,
+      }).eq("transfer_pair_id", editingTx.transfer_pair_id)
+      error = pairError
+    } else {
+      const { error: singleError } = await supabase.from("transactions").update({
+        type: editType,
+        amount: parseInt(editAmount),
+        category_id: editCategoryId,
+        account_id: editAccountId,
+        txn_date: editDate,
+        name: editName || null,
+        memo: editMemo || null,
+      }).eq("id", editingTx.id)
+      error = singleError
+    }
     setSaving(false)
     if (error) { alert("保存に失敗しました"); return }
     setEditingTx(null)
@@ -107,10 +123,23 @@ export default function TransactionsPage() {
   }
 
   async function handleDelete(id: string) {
-    const { error } = await supabase.from("transactions").delete().eq("id", id)
+    const target = transactions.find((t) => t.id === id)
+    const pairId = target?.transfer_pair_id
+
+    let error
+    if (pairId) {
+      // 振替ペアを両方削除
+      const { error: pairError } = await supabase.from("transactions").delete().eq("transfer_pair_id", pairId)
+      error = pairError
+    } else {
+      const { error: singleError } = await supabase.from("transactions").delete().eq("id", id)
+      error = singleError
+    }
     if (error) { alert("削除に失敗しました"); return }
     setDeletingTxId(null)
-    setTransactions((prev) => prev.filter((t) => t.id !== id))
+    setTransactions((prev) =>
+      pairId ? prev.filter((t) => t.transfer_pair_id !== pairId) : prev.filter((t) => t.id !== id)
+    )
   }
 
   const filteredTransactions = useMemo(() => transactions.filter((t) => {
@@ -321,7 +350,11 @@ export default function TransactionsPage() {
             <DialogTitle>明細を削除</DialogTitle>
           </DialogHeader>
           <div className="space-y-5 pt-2">
-            <p className="text-sm text-muted-foreground">この明細を削除します。元に戻せません。</p>
+            <p className="text-sm text-muted-foreground">
+              {transactions.find((t) => t.id === deletingTxId)?.transfer_pair_id
+                ? "振替の両方の明細が削除されます。元に戻せません。"
+                : "この明細を削除します。元に戻せません。"}
+            </p>
             <div className="flex gap-3">
               <Button
                 variant="outline"
@@ -350,21 +383,23 @@ export default function TransactionsPage() {
           </DialogHeader>
 
           <div className="space-y-5 pt-2">
-            {/* Type Toggle */}
-            <div className="flex rounded-full bg-muted p-1">
-              {(["expense", "income"] as TransactionType[]).map((t) => (
-                <button
-                  key={t}
-                  onClick={() => { setEditType(t); setEditCategoryId("") }}
-                  className={cn(
-                    "flex-1 py-2 rounded-full text-sm transition-all",
-                    editType === t ? "bg-card text-foreground shadow-sm" : "text-muted-foreground"
-                  )}
-                >
-                  {t === "expense" ? "支出" : "収入"}
-                </button>
-              ))}
-            </div>
+            {/* Type Toggle - 振替明細は種類変更不可 */}
+            {!editingTx?.transfer_pair_id && (
+              <div className="flex rounded-full bg-muted p-1">
+                {(["expense", "income"] as TransactionType[]).map((t) => (
+                  <button
+                    key={t}
+                    onClick={() => { setEditType(t); setEditCategoryId("") }}
+                    className={cn(
+                      "flex-1 py-2 rounded-full text-sm transition-all",
+                      editType === t ? "bg-card text-foreground shadow-sm" : "text-muted-foreground"
+                    )}
+                  >
+                    {t === "expense" ? "支出" : "収入"}
+                  </button>
+                ))}
+              </div>
+            )}
 
             {/* Name */}
             <div>
@@ -394,35 +429,39 @@ export default function TransactionsPage() {
               </div>
             </div>
 
-            {/* Category */}
-            <div>
-              <p className="text-xs tracking-wide uppercase text-muted-foreground mb-2">カテゴリ</p>
-              <Select value={editCategoryId} onValueChange={setEditCategoryId}>
-                <SelectTrigger className="rounded-xl border-0 bg-muted/50">
-                  <SelectValue placeholder="選択" />
-                </SelectTrigger>
-                <SelectContent>
-                  {editFilteredCategories.map((c) => (
-                    <SelectItem key={c.id} value={c.id}>{c.icon} {c.name}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
+            {/* Category - 振替明細は非表示 */}
+            {!editingTx?.transfer_pair_id && (
+              <div>
+                <p className="text-xs tracking-wide uppercase text-muted-foreground mb-2">カテゴリ</p>
+                <Select value={editCategoryId} onValueChange={setEditCategoryId}>
+                  <SelectTrigger className="rounded-xl border-0 bg-muted/50">
+                    <SelectValue placeholder="選択" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {editFilteredCategories.map((c) => (
+                      <SelectItem key={c.id} value={c.id}>{c.icon} {c.name}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
 
-            {/* Account */}
-            <div>
-              <p className="text-xs tracking-wide uppercase text-muted-foreground mb-2">口座</p>
-              <Select value={editAccountId} onValueChange={setEditAccountId}>
-                <SelectTrigger className="rounded-xl border-0 bg-muted/50">
-                  <SelectValue placeholder="選択" />
-                </SelectTrigger>
-                <SelectContent>
-                  {accounts.map((a) => (
-                    <SelectItem key={a.id} value={a.id}>{a.icon} {a.name}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
+            {/* Account - 振替明細は非表示 */}
+            {!editingTx?.transfer_pair_id && (
+              <div>
+                <p className="text-xs tracking-wide uppercase text-muted-foreground mb-2">口座</p>
+                <Select value={editAccountId} onValueChange={setEditAccountId}>
+                  <SelectTrigger className="rounded-xl border-0 bg-muted/50">
+                    <SelectValue placeholder="選択" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {accounts.map((a) => (
+                      <SelectItem key={a.id} value={a.id}>{a.icon} {a.name}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
 
             {/* Date */}
             <div>
@@ -451,7 +490,7 @@ export default function TransactionsPage() {
 
             <Button
               onClick={handleUpdate}
-              disabled={saving || !editAmount || !editCategoryId || !editAccountId}
+              disabled={saving || !editAmount || (!editingTx?.transfer_pair_id && (!editCategoryId || !editAccountId))}
               className="w-full rounded-xl"
             >
               {saving ? "保存中..." : "保存する"}

--- a/src/lib/data/index.ts
+++ b/src/lib/data/index.ts
@@ -138,6 +138,29 @@ export async function getTransactions(month?: string): Promise<Transaction[]> {
   })
 }
 
+// 振替カテゴリIDを取得（なければ is_active=false で自動作成）
+export async function getOrCreateTransferCategory(userId: string): Promise<string> {
+  const { data: existingCats, error: catFetchError } = await supabase
+    .from("categories")
+    .select("id")
+    .eq("type", "transfer")
+    .eq("user_id", userId)
+    .limit(1)
+  if (catFetchError) throw catFetchError
+
+  if (existingCats && existingCats.length > 0) {
+    return existingCats[0].id
+  }
+
+  const { data: newCat, error: catError } = await supabase
+    .from("categories")
+    .insert({ user_id: userId, name: "振替", type: "transfer", sort_order: 99, is_active: false })
+    .select("id")
+    .single()
+  if (catError || !newCat) throw catError
+  return newCat.id
+}
+
 export async function getTemplates(): Promise<RecurringTemplate[]> {
   const { data, error } = await supabase
     .from("recurring_templates")

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -49,5 +49,5 @@ export async function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|sw.js|manifest.webmanifest|.*\\.(?:png|svg|ico|jpg|jpeg|webp)).*)"],
 }


### PR DESCRIPTION
## Summary

- 振替（transfer_pair_id付き取引）がダッシュボード集計・引き落とし額計算に混入していたのを除外
- 振替ペアの削除・編集で片側だけ変更され整合性が壊れる問題を修正
- 未ログイン時にPWAアセットが/loginへリダイレクトされる問題と、設定画面の確認なし削除を修正

## 変更内容

**ダッシュボード（src/app/page.tsx）**
- 収入・支出・貯蓄率・カテゴリ円グラフの集計から振替を除外
- ローカル重複定義の shiftMonth を削除し @/lib/data からimport

**明細一覧（src/app/transactions/page.tsx）**
- 振替明細の削除時はペア両方を一括削除（確認ダイアログの文言も分岐）
- 振替明細の編集は金額・日付・品目名・メモのみ可とし、ペア両方に反映（種類・カテゴリ・口座は変更不可）

**月次レポート（src/app/monthly/page.tsx）**
- handleDebitTransfer の引き落とし額計算から振替expenseを除外（二重計上防止）

**データ層（src/lib/data/index.ts）**
- 振替カテゴリの取得/作成ロジックを getOrCreateTransferCategory() に集約（add/monthly の重複を解消）

**ミドルウェア（src/proxy.ts）**
- matcher に sw.js / manifest.webmanifest / 画像拡張子を追加し、未ログイン時のPWA破壊を修正

**設定画面（src/app/settings/page.tsx）**
- カテゴリ・口座・固定費テンプレートの削除に確認ダイアログを追加（即時削除を廃止）

## Test plan

- [ ] 振替を含む月のダッシュボードで収入・支出・貯蓄率・円グラフに振替が含まれないこと
- [ ] 明細一覧で振替を削除するとペア両方が消えること
- [ ] 振替の編集で金額・日付変更がペア両方に反映され、種類・カテゴリ・口座が変更できないこと
- [ ] 月次レポートのクレカ「引き落とし」ボタンの金額に振替分が含まれないこと
- [ ] 未ログイン状態で /manifest.webmanifest と /sw.js が200で返ること（PWAインストール可能）
- [ ] 設定画面でカテゴリ・口座・固定費の削除時に確認ダイアログが出ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)