### PR TITLE
feat: 品目名の履歴サジェスト・連続入力モード・PWAショートカット・月次推移グラフを追加

### DIFF
--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -1,13 +1,19 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useRef } from "react"
 import { useRouter } from "next/navigation"
 import Link from "next/link"
 import { AppLayout } from "@/components/app-layout"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
-import { getCategories, getAccounts, getOrCreateTransferCategory } from "@/lib/data"
+import {
+  getCategories,
+  getAccounts,
+  getOrCreateTransferCategory,
+  getEntrySuggestions,
+  EntrySuggestion,
+} from "@/lib/data"
 import { Category, Account, TransactionType } from "@/lib/types"
 import { supabase } from "@/lib/supabase"
 import { cn } from "@/lib/utils"
@@ -29,24 +35,79 @@ export default function AddTransactionPage() {
   const [categories, setCategories] = useState<Category[]>([])
   const [accounts, setAccounts] = useState<Account[]>([])
 
+  // 履歴サジェスト
+  const [suggestions, setSuggestions] = useState<EntrySuggestion[]>([])
+  const [filteredSuggestions, setFilteredSuggestions] = useState<EntrySuggestion[]>([])
+  const [showSuggestions, setShowSuggestions] = useState(false)
+  const nameContainerRef = useRef<HTMLDivElement>(null)
+
+  // 連続入力モード
+  const [continuousMode, setContinuousMode] = useState(false)
+  const [savedMessage, setSavedMessage] = useState<string | null>(null)
+
   useEffect(() => {
-    Promise.all([getCategories(), getAccounts()]).then(([cats, accs]) => {
-      setCategories(cats)
-      setAccounts(accs)
-      if (accs.length > 0) setSelectedAccount(accs[0].id)
-    })
+    Promise.all([getCategories(), getAccounts(), getEntrySuggestions()]).then(
+      ([cats, accs, suggs]) => {
+        setCategories(cats)
+        setAccounts(accs)
+        if (accs.length > 0) setSelectedAccount(accs[0].id)
+        setSuggestions(suggs)
+      }
+    )
+  }, [])
+
+  // 品目名エリア外クリックでサジェストを閉じる
+  useEffect(() => {
+    const handleOutsideClick = (e: MouseEvent) => {
+      if (
+        nameContainerRef.current &&
+        !nameContainerRef.current.contains(e.target as Node)
+      ) {
+        setShowSuggestions(false)
+      }
+    }
+    document.addEventListener("mousedown", handleOutsideClick)
+    return () => document.removeEventListener("mousedown", handleOutsideClick)
   }, [])
 
   const filteredCategories = categories.filter((c) => c.type === type)
+
+  const getCategoryIcon = (catId: string) =>
+    categories.find((c) => c.id === catId)?.icon ?? "📦"
 
   const handleTypeChange = (newType: TransactionType) => {
     setType(newType)
     setSelectedCategory("")
     setToAccount("")
+    setShowSuggestions(false)
   }
 
   const handleAmountChange = (value: string) => {
     setAmount(value.replace(/[^0-9]/g, ""))
+  }
+
+  const handleNameChange = (value: string) => {
+    setName(value)
+    if (!isTransfer && value.length > 0) {
+      const filtered = suggestions
+        .filter((s) => s.name.toLowerCase().includes(value.toLowerCase()))
+        .slice(0, 5)
+      setFilteredSuggestions(filtered)
+      setShowSuggestions(filtered.length > 0)
+    } else {
+      setShowSuggestions(false)
+    }
+  }
+
+  const applySuggestion = (s: EntrySuggestion) => {
+    setName(s.name)
+    if (s.type !== type) {
+      setType(s.type)
+      setToAccount("")
+    }
+    setSelectedCategory(s.category_id)
+    setSelectedAccount(s.account_id)
+    setShowSuggestions(false)
   }
 
   const formattedAmount = amount
@@ -68,59 +129,80 @@ export default function AddTransactionPage() {
     setSaving(true)
     setError(null)
 
-    const { data: { user } } = await supabase.auth.getUser()
-    if (!user) { setError("ログインが必要です"); setSaving(false); return }
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+    if (!user) {
+      setError("ログインが必要です")
+      setSaving(false)
+      return
+    }
 
     try {
       if (isTransfer) {
         const transferCategoryId = await getOrCreateTransferCategory(user.id)
         const pairId = crypto.randomUUID()
-        const { error: insertError } = await supabase.from("transactions").insert([
-          {
+        const { error: insertError } = await supabase
+          .from("transactions")
+          .insert([
+            {
+              user_id: user.id,
+              type: "expense",
+              amount: parseInt(amount),
+              category_id: transferCategoryId,
+              account_id: selectedAccount,
+              txn_date: date,
+              name: name || null,
+              memo: memo || null,
+              transfer_pair_id: pairId,
+            },
+            {
+              user_id: user.id,
+              type: "income",
+              amount: parseInt(amount),
+              category_id: transferCategoryId,
+              account_id: toAccount,
+              txn_date: date,
+              name: name || null,
+              memo: memo || null,
+              transfer_pair_id: pairId,
+            },
+          ])
+        if (insertError) throw insertError
+      } else {
+        const { error: insertError } = await supabase
+          .from("transactions")
+          .insert({
             user_id: user.id,
-            type: "expense",
+            type,
             amount: parseInt(amount),
-            category_id: transferCategoryId,
+            category_id: selectedCategory,
             account_id: selectedAccount,
             txn_date: date,
             name: name || null,
             memo: memo || null,
-            transfer_pair_id: pairId,
-          },
-          {
-            user_id: user.id,
-            type: "income",
-            amount: parseInt(amount),
-            category_id: transferCategoryId,
-            account_id: toAccount,
-            txn_date: date,
-            name: name || null,
-            memo: memo || null,
-            transfer_pair_id: pairId,
-          },
-        ])
-        if (insertError) throw insertError
-      } else {
-        const { error: insertError } = await supabase.from("transactions").insert({
-          user_id: user.id,
-          type,
-          amount: parseInt(amount),
-          category_id: selectedCategory,
-          account_id: selectedAccount,
-          txn_date: date,
-          name: name || null,
-          memo: memo || null,
-        })
+          })
         if (insertError) throw insertError
       }
 
-      setAmount("")
-      setSelectedCategory("")
-      setToAccount("")
-      setName("")
-      setMemo("")
-      setDate(new Date().toISOString().split("T")[0])
-      router.push("/")
+      if (continuousMode) {
+        // 日付は維持してフォームをリセット
+        setAmount("")
+        setSelectedCategory("")
+        setToAccount("")
+        setName("")
+        setMemo("")
+        setSavedMessage("保存しました")
+        setTimeout(() => setSavedMessage(null), 3000)
+      } else {
+        setAmount("")
+        setSelectedCategory("")
+        setToAccount("")
+        setName("")
+        setMemo("")
+        setDate(new Date().toISOString().split("T")[0])
+        router.push("/")
+      }
     } catch {
       setError("保存に失敗しました")
     } finally {
@@ -153,7 +235,11 @@ export default function AddTransactionPage() {
                 onChange={(e) => handleAmountChange(e.target.value)}
                 className={cn(
                   "text-5xl md:text-6xl font-light tracking-tight text-center bg-transparent border-none outline-none w-full tabular-nums",
-                  type === "income" ? "text-income" : type === "transfer" ? "text-muted-foreground" : "text-foreground"
+                  type === "income"
+                    ? "text-income"
+                    : type === "transfer"
+                    ? "text-muted-foreground"
+                    : "text-foreground"
                 )}
                 placeholder="0"
               />
@@ -166,7 +252,9 @@ export default function AddTransactionPage() {
               onClick={() => handleTypeChange("expense")}
               className={cn(
                 "flex-1 py-2.5 rounded-full text-sm transition-all",
-                type === "expense" ? "bg-card text-foreground shadow-sm" : "text-muted-foreground"
+                type === "expense"
+                  ? "bg-card text-foreground shadow-sm"
+                  : "text-muted-foreground"
               )}
             >
               支出
@@ -175,7 +263,9 @@ export default function AddTransactionPage() {
               onClick={() => handleTypeChange("income")}
               className={cn(
                 "flex-1 py-2.5 rounded-full text-sm transition-all",
-                type === "income" ? "bg-card text-foreground shadow-sm" : "text-muted-foreground"
+                type === "income"
+                  ? "bg-card text-foreground shadow-sm"
+                  : "text-muted-foreground"
               )}
             >
               収入
@@ -184,7 +274,9 @@ export default function AddTransactionPage() {
               onClick={() => handleTypeChange("transfer")}
               className={cn(
                 "flex-1 py-2.5 rounded-full text-sm transition-all",
-                type === "transfer" ? "bg-card text-foreground shadow-sm" : "text-muted-foreground"
+                type === "transfer"
+                  ? "bg-card text-foreground shadow-sm"
+                  : "text-muted-foreground"
               )}
             >
               振替
@@ -232,14 +324,24 @@ export default function AddTransactionPage() {
             </p>
             {accounts.length === 0 ? (
               <p className="text-sm text-muted-foreground">
-                口座がありません。<Link href="/settings?tab=accounts" className="underline underline-offset-2 hover:text-foreground transition-colors">設定画面で追加</Link>してください。
+                口座がありません。
+                <Link
+                  href="/settings?tab=accounts"
+                  className="underline underline-offset-2 hover:text-foreground transition-colors"
+                >
+                  設定画面で追加
+                </Link>
+                してください。
               </p>
             ) : (
               <div className="flex flex-wrap gap-2">
                 {accounts.map((account) => (
                   <button
                     key={account.id}
-                    onClick={() => { setSelectedAccount(account.id); if (toAccount === account.id) setToAccount("") }}
+                    onClick={() => {
+                      setSelectedAccount(account.id)
+                      if (toAccount === account.id) setToAccount("")
+                    }}
                     className={cn(
                       "flex items-center gap-2 px-4 py-2.5 rounded-full text-sm transition-all",
                       selectedAccount === account.id
@@ -263,7 +365,14 @@ export default function AddTransactionPage() {
               </p>
               {accounts.length <= 1 ? (
                 <p className="text-sm text-muted-foreground">
-                  振替には2つ以上の口座が必要です。<Link href="/settings?tab=accounts" className="underline underline-offset-2 hover:text-foreground transition-colors">設定画面で追加</Link>してください。
+                  振替には2つ以上の口座が必要です。
+                  <Link
+                    href="/settings?tab=accounts"
+                    className="underline underline-offset-2 hover:text-foreground transition-colors"
+                  >
+                    設定画面で追加
+                  </Link>
+                  してください。
                 </p>
               ) : (
                 <div className="flex flex-wrap gap-2">
@@ -289,18 +398,43 @@ export default function AddTransactionPage() {
             </div>
           )}
 
-          {/* Name */}
+          {/* Name（履歴サジェスト付き） */}
           <div>
             <p className="text-xs tracking-wide uppercase text-muted-foreground mb-4">
               品目名
             </p>
-            <Input
-              type="text"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="例：ランチ、スーパー"
-              className="h-12 rounded-xl bg-muted/30 border-0 text-foreground placeholder:text-muted-foreground/50"
-            />
+            <div ref={nameContainerRef} className="relative">
+              <Input
+                type="text"
+                value={name}
+                onChange={(e) => handleNameChange(e.target.value)}
+                onFocus={() => {
+                  if (!isTransfer && name.length > 0 && filteredSuggestions.length > 0) {
+                    setShowSuggestions(true)
+                  }
+                }}
+                placeholder="例：ランチ、スーパー"
+                className="h-12 rounded-xl bg-muted/30 border-0 text-foreground placeholder:text-muted-foreground/50"
+              />
+              {showSuggestions && filteredSuggestions.length > 0 && (
+                <div className="absolute top-full left-0 right-0 mt-1 z-50 rounded-xl bg-card border border-border shadow-md overflow-hidden">
+                  {filteredSuggestions.map((s, i) => (
+                    <button
+                      key={i}
+                      type="button"
+                      onMouseDown={(e) => {
+                        e.preventDefault()
+                        applySuggestion(s)
+                      }}
+                      className="w-full flex items-center gap-3 px-4 py-3 text-sm text-left hover:bg-muted/50 transition-colors"
+                    >
+                      <span className="text-base">{getCategoryIcon(s.category_id)}</span>
+                      <span className="text-foreground">{s.name}</span>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
           </div>
 
           {/* Date */}
@@ -332,16 +466,42 @@ export default function AddTransactionPage() {
             />
           </div>
 
+          {savedMessage && (
+            <p className="text-sm text-income text-center">{savedMessage}</p>
+          )}
           {error && <p className="text-sm text-destructive">{error}</p>}
 
-          {/* Submit Button */}
-          <Button
-            onClick={handleSubmit}
-            disabled={isSubmitDisabled}
-            className="w-full h-14 rounded-full text-base"
-          >
-            {saving ? "保存中..." : "保存する"}
-          </Button>
+          {/* 続けて入力する + 保存ボタン */}
+          <div className="space-y-4">
+            <div className="flex items-center justify-center gap-3">
+              <button
+                type="button"
+                role="switch"
+                aria-checked={continuousMode}
+                onClick={() => setContinuousMode(!continuousMode)}
+                className={cn(
+                  "relative inline-flex h-5 w-9 flex-shrink-0 items-center rounded-full transition-colors",
+                  continuousMode ? "bg-foreground" : "bg-muted"
+                )}
+              >
+                <span
+                  className={cn(
+                    "inline-block h-4 w-4 transform rounded-full bg-background transition-transform",
+                    continuousMode ? "translate-x-4" : "translate-x-0.5"
+                  )}
+                />
+              </button>
+              <span className="text-sm text-muted-foreground">続けて入力する</span>
+            </div>
+
+            <Button
+              onClick={handleSubmit}
+              disabled={isSubmitDisabled}
+              className="w-full h-14 rounded-full text-base"
+            >
+              {saving ? "保存中..." : "保存する"}
+            </Button>
+          </div>
         </div>
       </div>
     </AppLayout>

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -10,6 +10,14 @@ export default function manifest(): MetadataRoute.Manifest {
     background_color: "#f5f5f3",
     theme_color: "#f5f5f3",
     orientation: "portrait",
+    shortcuts: [
+      {
+        name: "新規入力",
+        short_name: "入力",
+        description: "新しい明細を追加する",
+        url: "/add",
+      },
+    ],
     icons: [
       {
         src: "/icon-192.png",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { AppLayout } from "@/components/app-layout"
 import { MonthSelector } from "@/components/month-selector"
 import { SummaryCard } from "@/components/summary-card"
 import { CategoryChart } from "@/components/category-chart"
+import { TrendChart, TrendDataPoint } from "@/components/trend-chart"
 import { RecentTransactions } from "@/components/recent-transactions"
 import { getTransactions, getCurrentMonth, shiftMonth } from "@/lib/data"
 import { Transaction } from "@/lib/types"
@@ -18,17 +19,53 @@ const CHART_COLORS = [
   "var(--color-muted-foreground)",
 ]
 
+const TREND_MONTHS = 6
+
+function toMonthLabel(month: string): string {
+  const match = month.match(/\d{4}年(\d{1,2}月)/)
+  return match ? match[1] : month
+}
 
 export default function DashboardPage() {
   const [currentMonth, setCurrentMonth] = useState(getCurrentMonth())
   const [transactions, setTransactions] = useState<Transaction[]>([])
+  const [trendData, setTrendData] = useState<TrendDataPoint[]>([])
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
+    let stale = false
     setLoading(true)
-    getTransactions(currentMonth)
-      .then(setTransactions)
-      .finally(() => setLoading(false))
+
+    const months = Array.from({ length: TREND_MONTHS }, (_, i) =>
+      shiftMonth(currentMonth, -(TREND_MONTHS - 1 - i))
+    )
+
+    Promise.all(months.map((m) => getTransactions(m))).then((results) => {
+      if (stale) return
+
+      // Current month transactions (last in the array)
+      setTransactions(results[TREND_MONTHS - 1])
+
+      // Build trend data for all 6 months
+      const trend: TrendDataPoint[] = months.map((month, i) => {
+        const nonTransfer = results[i].filter((t) => !t.transfer_pair_id)
+        const income = nonTransfer
+          .filter((t) => t.type === "income")
+          .reduce((s, t) => s + t.amount, 0)
+        const expense = nonTransfer
+          .filter((t) => t.type === "expense")
+          .reduce((s, t) => s + t.amount, 0)
+        return { month: toMonthLabel(month), income, expense }
+      })
+      setTrendData(trend)
+      setLoading(false)
+    }).catch(() => {
+      if (!stale) setLoading(false)
+    })
+
+    return () => {
+      stale = true
+    }
   }, [currentMonth])
 
   const monthlyData = useMemo(() => {
@@ -110,8 +147,13 @@ export default function DashboardPage() {
               </div>
             </div>
 
+            {/* Trend Chart */}
+            <div className="mt-8">
+              <TrendChart data={trendData} />
+            </div>
+
             {/* Recent Transactions */}
-            <div className="mt-12">
+            <div className="mt-8">
               <RecentTransactions transactions={transactions} />
             </div>
           </>

--- a/src/components/trend-chart.tsx
+++ b/src/components/trend-chart.tsx
@@ -1,0 +1,125 @@
+"use client"
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts"
+import { formatCurrency } from "@/lib/data"
+
+export interface TrendDataPoint {
+  month: string
+  income: number
+  expense: number
+}
+
+interface TrendChartProps {
+  data: TrendDataPoint[]
+}
+
+interface TooltipEntry {
+  name: string
+  value: number
+  color?: string
+}
+
+interface CustomTooltipProps {
+  active?: boolean
+  label?: string
+  payload?: TooltipEntry[]
+}
+
+function CustomTooltip({ active, payload, label }: CustomTooltipProps) {
+  if (!active || !payload || payload.length === 0) return null
+
+  return (
+    <div className="rounded-xl bg-card border border-border px-4 py-3 shadow-md text-sm space-y-1">
+      <p className="text-xs text-muted-foreground mb-2">{label}</p>
+      {payload.map((entry: TooltipEntry) => (
+        <div key={entry.name} className="flex items-center gap-2">
+          <span
+            className="inline-block h-2 w-2 rounded-full"
+            style={{ backgroundColor: entry.color }}
+          />
+          <span className="text-muted-foreground">
+            {entry.name === "income" ? "収入" : "支出"}
+          </span>
+          <span className="tabular-nums text-foreground ml-auto pl-4">
+            {formatCurrency(entry.value ?? 0)}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function TrendChart({ data }: TrendChartProps) {
+  return (
+    <div className="rounded-2xl bg-card p-6 md:p-8">
+      <p className="text-xs tracking-wide uppercase text-muted-foreground mb-6">
+        収支推移（直近6ヶ月）
+      </p>
+      <div className="h-52 w-full">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart
+            data={data}
+            barCategoryGap="30%"
+            barGap={3}
+            margin={{ top: 4, right: 4, left: 4, bottom: 0 }}
+          >
+            <CartesianGrid
+              vertical={false}
+              strokeDasharray="3 3"
+              stroke="var(--color-border)"
+              strokeOpacity={0.5}
+            />
+            <XAxis
+              dataKey="month"
+              axisLine={false}
+              tickLine={false}
+              tick={{ fontSize: 12, fill: "var(--color-muted-foreground)" }}
+            />
+            <YAxis hide />
+            <Tooltip
+              content={<CustomTooltip />}
+              cursor={{ fill: "var(--color-muted-foreground)", fillOpacity: 0.06 }}
+            />
+            <Bar
+              dataKey="income"
+              name="income"
+              fill="var(--color-income)"
+              radius={[4, 4, 0, 0]}
+            />
+            <Bar
+              dataKey="expense"
+              name="expense"
+              fill="var(--color-chart-1)"
+              radius={[4, 4, 0, 0]}
+            />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+      {/* Legend */}
+      <div className="flex items-center gap-6 mt-4">
+        <div className="flex items-center gap-2">
+          <span
+            className="inline-block h-2 w-2 rounded-full"
+            style={{ backgroundColor: "var(--color-income)" }}
+          />
+          <span className="text-xs text-muted-foreground">収入</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <span
+            className="inline-block h-2 w-2 rounded-full"
+            style={{ backgroundColor: "var(--color-chart-1)" }}
+          />
+          <span className="text-xs text-muted-foreground">支出</span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/data/index.ts
+++ b/src/lib/data/index.ts
@@ -1,5 +1,5 @@
 import { supabase } from "@/lib/supabase"
-import { Transaction, Category, Account, RecurringTemplate } from "@/lib/types"
+import { Transaction, Category, Account, RecurringTemplate, TransactionType } from "@/lib/types"
 
 // カテゴリアイコン静的マッピング（DBにiconが未設定の場合のフォールバック）
 const CATEGORY_ICONS: Record<string, string> = {
@@ -34,6 +34,16 @@ export const DEFAULT_CATEGORIES = [
   { name: "投資",     type: "expense", sort_order: 21, is_fixed: false },
   { name: "その他",   type: "expense", sort_order: 22, is_fixed: false },
 ] as const
+
+// --- 型定義 ---
+
+export type EntrySuggestion = {
+  name: string
+  category_id: string
+  account_id: string
+  type: TransactionType
+  amount: number
+}
 
 // --- データ取得関数 ---
 
@@ -136,6 +146,34 @@ export async function getTransactions(month?: string): Promise<Transaction[]> {
       transfer_pair_id: row.transfer_pair_id ?? null,
     }
   })
+}
+
+// 品目名サジェスト用: 直近200件の name 付き明細を取得し name で重複排除（最新優先）
+export async function getEntrySuggestions(): Promise<EntrySuggestion[]> {
+  const { data, error } = await supabase
+    .from("transactions")
+    .select("name, category_id, account_id, type, amount")
+    .not("name", "is", null)
+    .is("transfer_pair_id", null)
+    .order("created_at", { ascending: false })
+    .limit(200)
+
+  if (error) throw error
+
+  const seen = new Set<string>()
+  const result: EntrySuggestion[] = []
+  for (const row of data ?? []) {
+    if (!row.name || seen.has(row.name)) continue
+    seen.add(row.name)
+    result.push({
+      name: row.name,
+      category_id: row.category_id,
+      account_id: row.account_id,
+      type: row.type as TransactionType,
+      amount: Number(row.amount),
+    })
+  }
+  return result
 }
 
 // 振替カテゴリIDを取得（なければ is_active=false で自動作成）


### PR DESCRIPTION
## Summary

- 入力体験のクイック化: 品目名の履歴サジェスト（カテゴリ・口座も自動セット）、連続入力モード、PWAショートカット
- ダッシュボードに直近6ヶ月の収支推移グラフ（棒グラフ）を追加
- 「毎日使いやすい入力体験」と「Excel月次シートの代替」を強化

## 変更内容

**入力画面（src/app/add/page.tsx）**
- 品目名入力で過去明細から部分一致サジェストを最大5件表示。選択で品目名・カテゴリ・口座・収支タイプを自動セット（振替時は非表示）
- 「続けて入力する」トグルを追加。ON時は保存後に画面に留まり、日付を維持してフォームのみリセット＋「保存しました」を3秒表示

**データ層（src/lib/data/index.ts）**
- `getEntrySuggestions()` を追加: name付き明細を直近200件取得し name で重複排除（最新優先）。振替ペア（transfer_pair_id付き）は除外

**PWA（src/app/manifest.ts）**
- shortcuts に「新規入力 → /add」を追加（ホーム画面アイコン長押しで入力直行）

**ダッシュボード（src/app/page.tsx, src/components/trend-chart.tsx 新規）**
- 選択月を終点に直近6ヶ月分を並列取得し、収入・支出の推移を棒グラフ表示（円グラフの下）
- 振替（transfer_pair_id付き）は集計から除外
- 月切り替え連打時に古いレスポンスが上書きしないようステイルガードを実装

## Test plan

- [ ] 品目名を入力すると過去の明細からサジェストが出て、選択でカテゴリ・口座が自動セットされること
- [ ] 振替由来の品目名がサジェストに出ないこと
- [ ] 「続けて入力する」ON で保存後に画面に留まり、日付が維持されてフォームがリセットされること
- [ ] OFF のときは従来どおり保存後にダッシュボードへ遷移すること
- [ ] PWAのホーム画面アイコン長押しで「新規入力」ショートカットが表示されること（要再インストール）
- [ ] ダッシュボードに直近6ヶ月の収支推移グラフが表示され、月を切り替えると追従すること
- [ ] 推移グラフの金額に振替が含まれないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)