### PR TITLE
fix: 「最近の取引」に品目名を表示するよう修正

### DIFF
--- a/src/components/recent-transactions.tsx
+++ b/src/components/recent-transactions.tsx
@@ -34,7 +34,7 @@ export function RecentTransactions({ transactions }: RecentTransactionsProps) {
                   {transaction.icon ?? "📦"}
                 </div>
                 <div>
-                  <p className="text-sm font-medium text-foreground">{transaction.category}</p>
+                  <p className="text-sm font-medium text-foreground">{transaction.name || transaction.category}</p>
                   <p className="text-xs text-muted-foreground mt-0.5">
                     {formatDate(transaction.date)}
                   </p>


### PR DESCRIPTION
## 背景
明細一覧（/transactions）では品目名（name）が登録されていればそれを優先表示し、なければカテゴリ名にフォールバックする仕様だが、ダッシュボードの「最近の取引」（src/components/recent-transactions.tsx）はカテゴリ名しか表示していなかった。同じ取引でも画面によって表示が異なり混乱するため統一。

## 変更内容
- src/components/recent-transactions.tsx: 一覧行タイトルを `transaction.category` から `transaction.name || transaction.category`（/transactions/page.tsx と同じフォールバックパターン）に変更

## 受け入れ基準チェック
- [x] 「最近の取引」の各行で、nameが登録されている取引はその品目名が表示される: `transaction.name || transaction.category` で確認
- [x] nameが未登録の取引は、これまで通りカテゴリ名が表示される: `||` フォールバックで確認
- [x] 明細一覧ページ（/transactions）の表示・挙動は変更しない: git diffで対象ファイルが recent-transactions.tsx のみであることを確認

## 動作確認
npm run build 成功（TypeScriptエラーなし）

## レビュー観点
特になし（既存パターンの踏襲のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)