### PR TITLE
fix: 支出内訳グラフの凡例に「その他」が表示されない不具合を修正

### DIFF
--- a/src/components/category-chart.tsx
+++ b/src/components/category-chart.tsx
@@ -46,7 +46,7 @@ export function CategoryChart({ data }: CategoryChartProps) {
 
       {/* Legend */}
       <ul className="space-y-3">
-        {data.slice(0, 5).map((item, index) => {
+        {data.map((item, index) => {
           const percentage = ((item.value / total) * 100).toFixed(0)
           return (
             <li key={index} className="flex items-center justify-between">


### PR DESCRIPTION
## Summary
- `src/components/category-chart.tsx` の凡例部分が `data.slice(0, 5)` で先頭5件しか描画しておらず、カテゴリが6件以上ある月は円グラフ本体に描かれる「その他」が凡例からだけ消えていた（B-02）
- `page.tsx` 側で既に上位5カテゴリ+「その他」の最大6件に整形して渡しているため、凡例側の slice を外して全件描画するよう修正

## Test plan
- [ ] 支出カテゴリが6件以上ある月のダッシュボードを表示し、凡例に「その他」の行と割合(%)が表示されることを確認
- [ ] カテゴリが5件以下の月で表示が変わらないことを確認
- [ ] 凡例の割合(%)を合計しておおよそ100%になることを確認