### PR TITLE
fix: 口座の初期残高にマイナス値を入れた際にクライアント側でエラー表示

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -155,13 +155,15 @@ export default function SettingsPage() {
   // 口座追加
   async function handleAddAccount() {
     if (!newAccountName.trim()) return
+    const openingBalance = parseInt(newAccountBalance) || 0
+    if (openingBalance < 0) { alert("初期残高は0以上で入力してください"); return }
     const user = await getUser()
     if (!user) return
     const { error } = await supabase.from("accounts").insert({
       user_id: user.id,
       name: newAccountName.trim(),
       kind: newAccountKind,
-      opening_balance: parseInt(newAccountBalance) || 0,
+      opening_balance: openingBalance,
       sort_order: 99,
       is_active: true,
       debit_account_id: newAccountKind === "credit_card" && newAccountDebitId ? newAccountDebitId : null,
@@ -177,9 +179,11 @@ export default function SettingsPage() {
   // 口座名変更
   async function handleRenameAccount() {
     if (!editingAccount || !editAccountName.trim()) return
+    const editOpeningBalance = parseInt(editAccountBalance) || 0
+    if (editOpeningBalance < 0) { alert("初期残高は0以上で入力してください"); return }
     const { error } = await supabase.from("accounts").update({
       name: editAccountName.trim(),
-      opening_balance: parseInt(editAccountBalance) || 0,
+      opening_balance: editOpeningBalance,
       debit_account_id: editingAccount.kind === "credit_card" && editAccountDebitId ? editAccountDebitId : null,
     }).eq("id", editingAccount.id)
     if (error) { alert("変更に失敗しました"); return }


### PR DESCRIPTION
## Summary

- 口座の追加・編集フォームで初期残高にマイナス値を入力して保存すると、Supabaseへリクエストを送る前にクライアント側でチェックし「初期残高は0以上で入力してください」と表示するようにした
- `accounts` テーブルの `opening_balance >= 0` 制約違反によるSupabaseの生エラー（「追加に失敗しました」としか出ない）を回避

## 変更内容

- `src/app/settings/page.tsx`
  - `handleAddAccount`: `parseInt` 後にマイナス値ならinsert前に`alert`で中断
  - `handleRenameAccount`: 同様にupdate前にマイナス値をチェック

## Test plan

- [ ] 口座追加フォームで初期残高にマイナス値を入力→保存→「初期残高は0以上で入力してください」が表示され、Supabaseへのinsertが呼ばれないこと
- [ ] 口座編集フォームで初期残高にマイナス値を入力→保存→同様のエラーが表示され、Supabaseへのupdateが呼ばれないこと
- [ ] 0円・正の金額は従来通り保存できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)