### PR TITLE
fix: 固定費テンプレートの引落日入力に1〜31の範囲バリデーションを追加

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -27,6 +27,12 @@ import {
 
 type SettingsTab = "categories" | "accounts" | "templates"
 
+function isValidDayOfMonth(value: string): boolean {
+  if (!value.trim()) return false
+  const n = Number(value)
+  return Number.isInteger(n) && n >= 1 && n <= 31
+}
+
 const tabs = [
   { id: "categories" as const, label: "カテゴリ", icon: Tags },
   { id: "accounts" as const, label: "口座", icon: Wallet },
@@ -196,7 +202,7 @@ export default function SettingsPage() {
 
   // テンプレート追加
   async function handleAddTemplate() {
-    if (!newTplName.trim() || !newTplAmount || !newTplCategoryId || !newTplAccountId || !newTplDay) return
+    if (!newTplName.trim() || !newTplAmount || !newTplCategoryId || !newTplAccountId || !isValidDayOfMonth(newTplDay)) return
     const user = await getUser()
     if (!user) return
     const { error } = await supabase.from("recurring_templates").insert({
@@ -218,7 +224,7 @@ export default function SettingsPage() {
   async function handleUpdateTemplate() {
     const amount = parseInt(editTplAmount)
     const day = parseInt(editTplDay)
-    if (!editingTemplate || !editTplName.trim() || isNaN(amount) || !editTplCategoryId || !editTplAccountId || isNaN(day)) return
+    if (!editingTemplate || !editTplName.trim() || isNaN(amount) || !editTplCategoryId || !editTplAccountId || !isValidDayOfMonth(editTplDay)) return
     const { error } = await supabase.from("recurring_templates").update({
       name: editTplName.trim(),
       amount,
@@ -550,7 +556,10 @@ export default function SettingsPage() {
                           </SelectContent>
                         </Select>
                         <Input type="number" placeholder="引落日（1〜31）" min="1" max="31" value={newTplDay} onChange={(e) => setNewTplDay(e.target.value)} className="rounded-xl" />
-                        <Button onClick={handleAddTemplate} disabled={!newTplName || !newTplAmount || !newTplCategoryId || !newTplAccountId || !newTplDay} className="w-full rounded-xl">
+                        {newTplDay && !isValidDayOfMonth(newTplDay) && (
+                          <p className="text-xs text-destructive">引落日は1〜31の範囲で入力してください</p>
+                        )}
+                        <Button onClick={handleAddTemplate} disabled={!newTplName || !newTplAmount || !newTplCategoryId || !newTplAccountId || !isValidDayOfMonth(newTplDay)} className="w-full rounded-xl">
                           追加する
                         </Button>
                       </div>
@@ -710,7 +719,10 @@ export default function SettingsPage() {
               </SelectContent>
             </Select>
             <Input type="number" placeholder="引落日（1〜31）" min="1" max="31" value={editTplDay} onChange={(e) => setEditTplDay(e.target.value)} className="rounded-xl" />
-            <Button onClick={handleUpdateTemplate} disabled={!editTplName.trim() || !editTplAmount || !editTplCategoryId || !editTplAccountId || !editTplDay} className="w-full rounded-xl">保存する</Button>
+            {editTplDay && !isValidDayOfMonth(editTplDay) && (
+              <p className="text-xs text-destructive">引落日は1〜31の範囲で入力してください</p>
+            )}
+            <Button onClick={handleUpdateTemplate} disabled={!editTplName.trim() || !editTplAmount || !editTplCategoryId || !editTplAccountId || !isValidDayOfMonth(editTplDay)} className="w-full rounded-xl">保存する</Button>
           </div>
         </DialogContent>
       </Dialog>


### PR DESCRIPTION
## 背景
固定費テンプレートの追加・編集フォームで、引落日入力欄は `type="number" min="1" max="31"` の属性のみで実際の値チェックがなく、0・32・マイナスなど範囲外の値を入力・送信できた。`recurring_templates` テーブルには `day_of_month between 1 and 31` の制約があるため、保存時にSupabase側の制約違反でエラーになっていた。

## 変更内容
- `isValidDayOfMonth()` ヘルパーを追加し、引落日が1〜31の整数かどうかを判定
- 追加・編集フォームの保存ボタンの `disabled` 条件に組み込み、範囲外の値では保存不可に
- 引落日が範囲外のとき、インラインで「引落日は1〜31の範囲で入力してください」を表示
- `handleAddTemplate` / `handleUpdateTemplate` のガード条件にも同関数を追加し、UI操作を経由しない呼び出しでもDB送信をブロック

## 受け入れ基準チェック
- [x] 基準1: 引落日に0/32/-5等を入力すると保存ボタンが disabled になり、インラインエラーメッセージを表示。ハンドラ側のガードでも二重に弾くためDB送信されない
- [x] 基準2: 1〜31の整数はこれまで通り正常に保存できる（バリデーションロジック・送信ロジック自体は変更なし）
- [x] 基準3: 既存の追加・更新失敗時のalertメッセージは変更しておらず、Supabaseの生エラーメッセージは表示していない（元から表示していなかった）

## 動作確認
- `npx tsc --noEmit` がエラーなしで通ることを確認

## レビュー観点
- インラインエラーメッセージの文言・表示位置が適切か
- disabled条件とhandler内ガードの二重チェックが冗長すぎないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)