### PR TITLE
feat: カテゴリ追加・編集で固定費フラグ(is_fixed)を設定できるように

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -44,12 +44,14 @@ export default function SettingsPage() {
   const [newCategoryName, setNewCategoryName] = useState("")
   const [newCategoryIcon, setNewCategoryIcon] = useState("")
   const [newCategoryType, setNewCategoryType] = useState<"income" | "expense">("expense")
+  const [newCategoryIsFixed, setNewCategoryIsFixed] = useState(false)
   const [addCategoryOpen, setAddCategoryOpen] = useState(false)
 
   // カテゴリ編集
   const [editingCategory, setEditingCategory] = useState<Category | null>(null)
   const [editCategoryName, setEditCategoryName] = useState("")
   const [editCategoryIcon, setEditCategoryIcon] = useState("")
+  const [editCategoryIsFixed, setEditCategoryIsFixed] = useState(false)
 
   // 口座追加
   const [newAccountName, setNewAccountName] = useState("")
@@ -123,12 +125,13 @@ export default function SettingsPage() {
       icon: newCategoryIcon.trim() || null,
       type: newCategoryType,
       sort_order: 99,
-      is_fixed: false,
+      is_fixed: newCategoryType === "expense" ? newCategoryIsFixed : false,
       is_active: true,
     })
     if (error) { alert("追加に失敗しました"); return }
     setNewCategoryName("")
     setNewCategoryIcon("")
+    setNewCategoryIsFixed(false)
     setAddCategoryOpen(false)
     loadData()
   }
@@ -139,6 +142,7 @@ export default function SettingsPage() {
     const { error } = await supabase.from("categories").update({
       name: editCategoryName.trim(),
       icon: editCategoryIcon.trim() || null,
+      is_fixed: editingCategory.type === "expense" ? editCategoryIsFixed : false,
     }).eq("id", editingCategory.id)
     if (error) { alert("変更に失敗しました"); return }
     setEditingCategory(null)
@@ -325,7 +329,7 @@ export default function SettingsPage() {
             </div>
             <div className="flex items-center gap-1">
               <button
-                onClick={() => { setEditingCategory(category); setEditCategoryName(category.name); setEditCategoryIcon(category.icon) }}
+                onClick={() => { setEditingCategory(category); setEditCategoryName(category.name); setEditCategoryIcon(category.icon); setEditCategoryIsFixed(category.is_fixed) }}
                 className="p-2 text-muted-foreground hover:text-foreground transition-colors"
               >
                 <Pencil className="h-4 w-4" />
@@ -427,6 +431,26 @@ export default function SettingsPage() {
                             <Input placeholder="カテゴリ名" value={newCategoryName} onChange={(e) => setNewCategoryName(e.target.value)} className="rounded-xl flex-1" />
                           </div>
                           <p className="text-xs text-muted-foreground">絵文字は省略可（自動で割り当てます）</p>
+                          <div className="flex items-center justify-between rounded-xl bg-muted/30 px-4 py-3">
+                            <span className="text-sm text-foreground">固定費として扱う</span>
+                            <button
+                              type="button"
+                              role="switch"
+                              aria-checked={newCategoryIsFixed}
+                              onClick={() => setNewCategoryIsFixed(!newCategoryIsFixed)}
+                              className={cn(
+                                "relative inline-flex h-5 w-9 flex-shrink-0 items-center rounded-full transition-colors",
+                                newCategoryIsFixed ? "bg-foreground" : "bg-muted"
+                              )}
+                            >
+                              <span
+                                className={cn(
+                                  "inline-block h-4 w-4 transform rounded-full bg-background transition-transform",
+                                  newCategoryIsFixed ? "translate-x-4" : "translate-x-0.5"
+                                )}
+                              />
+                            </button>
+                          </div>
                           <Button onClick={handleAddCategory} disabled={!newCategoryName.trim()} className="w-full rounded-xl">追加する</Button>
                         </div>
                       </DialogContent>
@@ -627,6 +651,28 @@ export default function SettingsPage() {
               <Input placeholder="絵文字" value={editCategoryIcon} onChange={(e) => setEditCategoryIcon(e.target.value)} className="rounded-xl w-20 text-center text-lg" maxLength={8} />
               <Input value={editCategoryName} onChange={(e) => setEditCategoryName(e.target.value)} className="rounded-xl flex-1" />
             </div>
+            {editingCategory?.type === "expense" && (
+              <div className="flex items-center justify-between rounded-xl bg-muted/30 px-4 py-3">
+                <span className="text-sm text-foreground">固定費として扱う</span>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={editCategoryIsFixed}
+                  onClick={() => setEditCategoryIsFixed(!editCategoryIsFixed)}
+                  className={cn(
+                    "relative inline-flex h-5 w-9 flex-shrink-0 items-center rounded-full transition-colors",
+                    editCategoryIsFixed ? "bg-foreground" : "bg-muted"
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "inline-block h-4 w-4 transform rounded-full bg-background transition-transform",
+                      editCategoryIsFixed ? "translate-x-4" : "translate-x-0.5"
+                    )}
+                  />
+                </button>
+              </div>
+            )}
             <Button onClick={handleRenameCategory} disabled={!editCategoryName.trim()} className="w-full rounded-xl">保存する</Button>
           </div>
         </DialogContent>


### PR DESCRIPTION
## Summary

- 支出カテゴリの「追加」ダイアログに固定費ON/OFFトグルを追加し、ONで保存すると `is_fixed: true` で登録されるようにした
- 支出カテゴリの「編集」ダイアログにも同トグルを追加し、既存カテゴリの `is_fixed` 値を初期表示に反映、保存で更新できるようにした
- 収入カテゴリの追加・編集フォームにはトグルを表示せず、送信時も `type === "expense"` でガードして `is_fixed` を常に `false` にすることで既存の収入カテゴリ挙動に影響しないようにした

## 変更内容

- `src/app/settings/page.tsx`
  - `newCategoryIsFixed` / `editCategoryIsFixed` の state を追加
  - `handleAddCategory` / `handleRenameCategory` の insert/update ペイロードに `is_fixed` を追加（支出のみトグル値、収入は常に `false`）
  - 支出カテゴリ「追加」ダイアログにトグルUIを追加（`add/page.tsx` の既存スイッチスタイルを踏襲）
  - カテゴリ編集ダイアログに `editingCategory?.type === "expense"` の場合のみトグルを表示、編集開始時に `category.is_fixed` を初期値としてセット

## 受け入れ基準

- [x] 支出カテゴリの「追加」ダイアログに固定費ON/OFFのトグルがあり、ONで保存すると `is_fixed: true` で登録される
- [x] 支出カテゴリの「編集」ダイアログでも固定費フラグをON/OFFして保存でき、既存カテゴリの値が初期表示に反映される
- [x] 収入カテゴリの追加・編集ではトグルを表示せず、送信時も常に `is_fixed: false`（既存挙動に影響なし）

## Test plan

- [x] `npm run build` が成功することを確認済み（型エラーなし）
- [ ] ブラウザでの手動確認は未実施（`/settings` は認証必須のため、ログイン情報がないローカル環境では動作確認できず）。マージ前にログイン可能な環境で以下を確認してください:
  - [ ] 支出カテゴリ追加でトグルON→固定費として登録される
  - [ ] 支出カテゴリ編集で既存の固定費フラグが反映され、ON/OFF切り替えて保存できる
  - [ ] 収入カテゴリの追加・編集にトグルが出ず、既存挙動に変化がない
  - [ ] `/monthly` の固定費/変動費集計に新規登録カテゴリが正しく反映される

🤖 Generated with [Claude Code](https://claude.com/claude-code)