### PR TITLE
feat: 口座にカスタム絵文字アイコンを設定できるようにする

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -53,6 +53,7 @@ export default function SettingsPage() {
 
   // 口座追加
   const [newAccountName, setNewAccountName] = useState("")
+  const [newAccountIcon, setNewAccountIcon] = useState("")
   const [newAccountKind, setNewAccountKind] = useState<"bank" | "cash" | "credit_card" | "e_money">("bank")
   const [newAccountBalance, setNewAccountBalance] = useState("")
   const [newAccountDebitId, setNewAccountDebitId] = useState("")
@@ -61,6 +62,7 @@ export default function SettingsPage() {
   // 口座編集
   const [editingAccount, setEditingAccount] = useState<Account | null>(null)
   const [editAccountName, setEditAccountName] = useState("")
+  const [editAccountIcon, setEditAccountIcon] = useState("")
   const [editAccountBalance, setEditAccountBalance] = useState("")
   const [editAccountDebitId, setEditAccountDebitId] = useState("")
 
@@ -160,6 +162,7 @@ export default function SettingsPage() {
     const { error } = await supabase.from("accounts").insert({
       user_id: user.id,
       name: newAccountName.trim(),
+      icon: newAccountIcon.trim() || null,
       kind: newAccountKind,
       opening_balance: parseInt(newAccountBalance) || 0,
       sort_order: 99,
@@ -168,6 +171,7 @@ export default function SettingsPage() {
     })
     if (error) { alert("追加に失敗しました"); return }
     setNewAccountName("")
+    setNewAccountIcon("")
     setNewAccountBalance("")
     setNewAccountDebitId("")
     setAddAccountOpen(false)
@@ -179,6 +183,7 @@ export default function SettingsPage() {
     if (!editingAccount || !editAccountName.trim()) return
     const { error } = await supabase.from("accounts").update({
       name: editAccountName.trim(),
+      icon: editAccountIcon.trim() || null,
       opening_balance: parseInt(editAccountBalance) || 0,
       debit_account_id: editingAccount.kind === "credit_card" && editAccountDebitId ? editAccountDebitId : null,
     }).eq("id", editingAccount.id)
@@ -449,7 +454,11 @@ export default function SettingsPage() {
                     <DialogContent className="rounded-2xl">
                       <DialogHeader><DialogTitle>口座を追加</DialogTitle></DialogHeader>
                       <div className="space-y-4 pt-4">
-                        <Input placeholder="口座名" value={newAccountName} onChange={(e) => setNewAccountName(e.target.value)} className="rounded-xl" />
+                        <div className="flex gap-2">
+                          <Input placeholder="絵文字" value={newAccountIcon} onChange={(e) => setNewAccountIcon(e.target.value)} className="rounded-xl w-20 text-center text-lg" maxLength={8} />
+                          <Input placeholder="口座名" value={newAccountName} onChange={(e) => setNewAccountName(e.target.value)} className="rounded-xl flex-1" />
+                        </div>
+                        <p className="text-xs text-muted-foreground">絵文字は省略可（自動で割り当てます）</p>
                         <Select value={newAccountKind} onValueChange={(v) => { setNewAccountKind(v as typeof newAccountKind); setNewAccountDebitId("") }}>
                           <SelectTrigger className="rounded-xl"><SelectValue placeholder="種類" /></SelectTrigger>
                           <SelectContent>
@@ -491,7 +500,7 @@ export default function SettingsPage() {
                         </div>
                         <div className="flex items-center gap-1">
                           <button
-                            onClick={() => { setEditingAccount(account); setEditAccountName(account.name); setEditAccountBalance(String(account.opening_balance ?? 0)); setEditAccountDebitId(account.debit_account_id ?? "") }}
+                            onClick={() => { setEditingAccount(account); setEditAccountName(account.name); setEditAccountIcon(account.icon ?? ""); setEditAccountBalance(String(account.opening_balance ?? 0)); setEditAccountDebitId(account.debit_account_id ?? "") }}
                             className="p-2 text-muted-foreground hover:text-foreground transition-colors"
                           >
                             <Pencil className="h-4 w-4" />
@@ -637,7 +646,10 @@ export default function SettingsPage() {
         <DialogContent className="rounded-2xl max-w-sm">
           <DialogHeader><DialogTitle>口座を編集</DialogTitle></DialogHeader>
           <div className="space-y-4 pt-4">
-            <Input value={editAccountName} onChange={(e) => setEditAccountName(e.target.value)} className="rounded-xl" placeholder="口座名" />
+            <div className="flex gap-2">
+              <Input placeholder="絵文字" value={editAccountIcon} onChange={(e) => setEditAccountIcon(e.target.value)} className="rounded-xl w-20 text-center text-lg" maxLength={8} />
+              <Input value={editAccountName} onChange={(e) => setEditAccountName(e.target.value)} className="rounded-xl flex-1" placeholder="口座名" />
+            </div>
             {editingAccount?.kind === "credit_card" && (
               <Select value={editAccountDebitId} onValueChange={setEditAccountDebitId}>
                 <SelectTrigger className="rounded-xl"><SelectValue placeholder="引き落とし元口座（任意）" /></SelectTrigger>

--- a/src/lib/data/index.ts
+++ b/src/lib/data/index.ts
@@ -69,7 +69,7 @@ export async function getCategories(): Promise<Category[]> {
 export async function getAccounts(untilDate?: string): Promise<Account[]> {
   const { data: accountsData, error } = await supabase
     .from("accounts")
-    .select("id, name, kind, opening_balance, debit_account_id")
+    .select("id, name, kind, opening_balance, debit_account_id, icon")
     .eq("is_active", true)
     .order("sort_order")
     .order("name")
@@ -96,7 +96,7 @@ export async function getAccounts(untilDate?: string): Promise<Account[]> {
     kind: row.kind,
     opening_balance: Number(row.opening_balance),
     balance: Number(row.opening_balance) + (balanceMap[row.id] ?? 0),
-    icon: ACCOUNT_ICONS[row.kind] ?? "🏦",
+    icon: row.icon ?? ACCOUNT_ICONS[row.kind] ?? "🏦",
     debit_account_id: row.debit_account_id ?? null,
   }))
 }

--- a/supabase/migrations/20260711000001_add_icon_to_accounts.sql
+++ b/supabase/migrations/20260711000001_add_icon_to_accounts.sql
@@ -1,0 +1,2 @@
+-- accounts テーブルに icon カラムを追加
+alter table accounts add column if not exists icon text;


### PR DESCRIPTION
## 背景
カテゴリはicon列を持ちユーザーが好きな絵文字を設定できるが、口座は kind ごとの固定絵文字（ACCOUNT_ICONS）のみで、銀行口座を複数登録すると全部🏦で見分けがつかない問題があった。

## 変更内容
- `accounts` テーブルに `icon` カラムを追加するマイグレーションを追加（`supabase/migrations/20260711000001_add_icon_to_accounts.sql`）
- `getAccounts()` で `icon` を取得し、未設定時は従来通り `ACCOUNT_ICONS[kind]` にフォールバックするよう変更（カテゴリのicon実装と同じパターン）
- 口座の「追加」「編集」ダイアログに絵文字入力欄を追加し、保存時にDBの `icon` に反映されるようにした

## 受け入れ基準チェック
- [x] `accounts` テーブルに `icon` カラムを追加するマイグレーションファイルが追加されている: `supabase/migrations/20260711000001_add_icon_to_accounts.sql` を追加
- [x] 口座の「追加」「編集」ダイアログに絵文字入力欄があり、入力して保存するとDBの `icon` に反映される: `src/app/settings/page.tsx` の `handleAddAccount`/`handleRenameAccount` で `icon` を保存するよう実装
- [x] 絵文字が未設定の口座は、これまで通り `kind` ごとのデフォルト絵文字（`ACCOUNT_ICONS`）にフォールバックする: `src/lib/data/index.ts` の `getAccounts()` を `row.icon ?? ACCOUNT_ICONS[row.kind] ?? "🏦"` に変更

## 動作確認
- `npm run build` が成功することを確認

## レビュー観点
- カテゴリのicon実装（`supabase/migrations/20260411000001_add_icon_to_categories.sql` 等）と同じパターンを踏襲しているか

🤖 Generated with [Claude Code](https://claude.com/claude-code)