### PR TITLE
fix: 固定費一括登録の名称をnameに保存し履歴で名称表示されるように修正

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -294,7 +294,7 @@ export default function DashboardPage() {
                     >
                       <span className="text-[15px]">{t.icon ?? "📦"}</span>
                       <div className="flex-1 min-w-0">
-                        <p className="text-[13.5px] truncate m-0">{t.name || t.category}</p>
+                        <p className="text-[13.5px] truncate m-0">{t.name || t.memo || t.category}</p>
                         <p className="text-[11px] mt-0.5 m-0" style={{ color: "oklch(0.58 0.008 260)" }}>
                           {formatDate(t.date)}・{t.account}
                         </p>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -291,17 +291,17 @@ export default function SettingsPage() {
     const monthStart = `${year}-${String(month).padStart(2, "0")}-01`
     const monthEnd = `${year}-${String(month).padStart(2, "0")}-${String(lastDay).padStart(2, "0")}`
 
-    // 今月すでに登録済みのテンプレート名（memo）を取得して重複防止
+    // 今月すでに登録済みのテンプレート名を取得して重複防止（旧データは memo に入っているため両方見る）
     const { data: existing } = await supabase
       .from("transactions")
-      .select("memo")
+      .select("name, memo")
       .eq("user_id", user.id)
       .gte("txn_date", monthStart)
       .lte("txn_date", monthEnd)
-    const existingMemos = new Set((existing ?? []).map((r) => r.memo))
+    const existingNames = new Set((existing ?? []).flatMap((r) => [r.name, r.memo]))
 
     const rows = templates
-      .filter((tpl) => !existingMemos.has(tpl.name))
+      .filter((tpl) => !existingNames.has(tpl.name))
       .map((tpl) => {
         const day = Math.min(tpl.day_of_month, lastDay)
         const txn_date = `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`
@@ -312,7 +312,7 @@ export default function SettingsPage() {
           category_id: tpl.category_id,
           account_id: tpl.account_id,
           txn_date,
-          memo: tpl.name,
+          name: tpl.name,
         }
       })
 

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -309,10 +309,10 @@ export default function TransactionsPage() {
                           </div>
                           <div className="flex-1 min-w-0">
                             <p className="text-sm text-foreground truncate">
-                              {transaction.name || transaction.category}
+                              {transaction.name || transaction.memo || transaction.category}
                             </p>
                             <p className="text-[11.5px] text-muted-foreground mt-0.5 truncate">
-                              {transaction.name && `${transaction.category} ・ `}
+                              {(transaction.name || transaction.memo) && `${transaction.category} ・ `}
                               {transaction.account}
                             </p>
                           </div>


### PR DESCRIPTION
## 背景

固定費テンプレートを一括登録すると、入力した名称が明細の `memo` カラムに保存されていた。履歴・ダッシュボードのタイトルは `name` を参照するため、名称ではなくカテゴリ名が表示されてしまっていた。

## 変更内容

- `settings/page.tsx`: テンプレ適用時に名称を `memo` ではなく `name` に保存。重複チェックは旧データ（memo に名称が入っている明細）も検知できるよう `name` と `memo` の両方を参照
- `transactions/page.tsx` / `page.tsx`(Dashboard): タイトル表示を `name → memo → カテゴリ` のフォールバックに変更し、過去に登録済みの固定費もデータ修正なしで名称表示

## 受け入れ基準チェック

- [x] 固定費一括登録で作られた明細が履歴で名称表示される（ローカルで表示確認）
- [x] 過去に登録済み（memo に名称）の明細も名称表示される（Netflix 等で確認）
- [x] 同月の重複登録防止が新旧データ両方で機能する（name/memo 両方をチェック）

## 動作確認

- `npm run build` 成功
- ローカル（localhost:3000）で History / Dashboard Recent の両方を目視確認。「給料」「cafe」「Netflix」が名称で表示され、サブ行にカテゴリ・口座が表示されること確認

## レビュー観点

- 表示フォールバックに memo を挟んだことで、手入力で memo だけ付けた明細もタイトルが memo になる（仕様として許容するかどうか）

🤖 Generated with [Claude Code](https://claude.com/claude-code)