### PR TITLE
feat: 明細追加のカテゴリを使用頻度順の上位8個に折りたたみiPad横で1画面に収める

### DIFF
--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -9,6 +9,7 @@ import {
   getAccounts,
   getOrCreateTransferCategory,
   getEntrySuggestions,
+  getCategoryUsageCounts,
   EntrySuggestion,
 } from "@/lib/data"
 import { Category, Account, TransactionType } from "@/lib/types"
@@ -30,6 +31,8 @@ export default function AddTransactionPage() {
 
   const [categories, setCategories] = useState<Category[]>([])
   const [accounts, setAccounts] = useState<Account[]>([])
+  const [usageCounts, setUsageCounts] = useState<Record<string, number>>({})
+  const [categoriesExpanded, setCategoriesExpanded] = useState(false)
 
   // 履歴サジェスト
   const [suggestions, setSuggestions] = useState<EntrySuggestion[]>([])
@@ -42,14 +45,18 @@ export default function AddTransactionPage() {
   const [savedMessage, setSavedMessage] = useState<string | null>(null)
 
   useEffect(() => {
-    Promise.all([getCategories(), getAccounts(), getEntrySuggestions()]).then(
-      ([cats, accs, suggs]) => {
-        setCategories(cats)
-        setAccounts(accs)
-        if (accs.length > 0) setSelectedAccount(accs[0].id)
-        setSuggestions(suggs)
-      }
-    )
+    Promise.all([
+      getCategories(),
+      getAccounts(),
+      getEntrySuggestions(),
+      getCategoryUsageCounts(),
+    ]).then(([cats, accs, suggs, counts]) => {
+      setCategories(cats)
+      setAccounts(accs)
+      if (accs.length > 0) setSelectedAccount(accs[0].id)
+      setSuggestions(suggs)
+      setUsageCounts(counts)
+    })
   }, [])
 
   // 品目名エリア外クリックでサジェストを閉じる
@@ -66,7 +73,23 @@ export default function AddTransactionPage() {
     return () => document.removeEventListener("mousedown", handleOutsideClick)
   }, [])
 
-  const filteredCategories = categories.filter((c) => c.type === type)
+  // 直近3ヶ月の使用頻度順（同数・履歴なしは getCategories の登録順を維持）
+  const INITIAL_CATEGORY_COUNT = 8
+  const filteredCategories = categories
+    .filter((c) => c.type === type)
+    .sort((a, b) => (usageCounts[b.id] ?? 0) - (usageCounts[a.id] ?? 0))
+
+  const isCategoryCollapsible = filteredCategories.length > INITIAL_CATEGORY_COUNT
+  const visibleCategories = (() => {
+    if (!isCategoryCollapsible || categoriesExpanded) return filteredCategories
+    const top = filteredCategories.slice(0, INITIAL_CATEGORY_COUNT)
+    // 選択中カテゴリが上位8個の外にある場合は末尾と入れ替えて見えるようにする
+    if (selectedCategory && !top.some((c) => c.id === selectedCategory)) {
+      const selected = filteredCategories.find((c) => c.id === selectedCategory)
+      if (selected) top[INITIAL_CATEGORY_COUNT - 1] = selected
+    }
+    return top
+  })()
 
   const getCategoryIcon = (catId: string) =>
     categories.find((c) => c.id === catId)?.icon ?? "📦"
@@ -76,6 +99,7 @@ export default function AddTransactionPage() {
     setSelectedCategory("")
     setToAccount("")
     setShowSuggestions(false)
+    setCategoriesExpanded(false)
   }
 
   const handleAmountChange = (value: string) => {
@@ -284,8 +308,8 @@ export default function AddTransactionPage() {
         <div className="lg:[&>:first-child]:mt-0">
         {/* Category Selection (非表示 when transfer) */}
         {!isTransfer && (
-          <div className="mt-10">
-            <p className="text-[11px] tracking-[0.12em] text-muted-foreground mb-4">
+          <div className="mt-10 lg:mt-7">
+            <p className="text-[11px] tracking-[0.12em] text-muted-foreground mb-4 lg:mb-3">
               カテゴリ
             </p>
             {filteredCategories.length === 0 ? (
@@ -293,13 +317,13 @@ export default function AddTransactionPage() {
                 カテゴリがありません。設定画面で追加してください。
               </p>
             ) : (
-              <div className="grid grid-cols-4 gap-2">
-                {filteredCategories.map((category) => (
+              <div className="grid grid-cols-4 lg:grid-cols-5 gap-2">
+                {visibleCategories.map((category) => (
                   <button
                     key={category.id}
                     onClick={() => setSelectedCategory(category.id)}
                     className={cn(
-                      "flex flex-col items-center justify-center gap-1.5 py-3.5 px-2 rounded-[6px] border transition-colors",
+                      "flex flex-col items-center justify-center gap-1.5 py-3.5 lg:py-2.5 px-2 rounded-[6px] border transition-colors",
                       selectedCategory === category.id
                         ? "border-primary bg-primary/5"
                         : "border-transparent"
@@ -318,14 +342,25 @@ export default function AddTransactionPage() {
                     </span>
                   </button>
                 ))}
+                {isCategoryCollapsible && (
+                  <button
+                    onClick={() => setCategoriesExpanded(!categoriesExpanded)}
+                    className="flex flex-col items-center justify-center gap-1.5 py-3.5 lg:py-2.5 px-2 rounded-[6px] border border-dashed border-border-mid transition-colors"
+                  >
+                    <span className="text-[19px]">{categoriesExpanded ? "−" : "⋯"}</span>
+                    <span className="text-[11.5px] truncate w-full text-center text-muted-foreground">
+                      {categoriesExpanded ? "閉じる" : "すべて表示"}
+                    </span>
+                  </button>
+                )}
               </div>
             )}
           </div>
         )}
 
         {/* Account Selection */}
-        <div className="mt-9">
-          <p className="text-[11px] tracking-[0.12em] text-muted-foreground mb-3.5">
+        <div className="mt-9 lg:mt-7">
+          <p className="text-[11px] tracking-[0.12em] text-muted-foreground mb-3.5 lg:mb-3">
             {isTransfer ? "送金元口座" : "口座"}
           </p>
           {accounts.length === 0 ? (
@@ -405,7 +440,7 @@ export default function AddTransactionPage() {
         )}
 
         {/* Name + Date */}
-        <div className="mt-10 lg:mt-8 grid grid-cols-1 md:grid-cols-[1fr_220px] gap-6 md:gap-10">
+        <div className="mt-10 lg:mt-6 grid grid-cols-1 md:grid-cols-[1fr_220px] gap-6 md:gap-10">
           {/* Name（履歴サジェスト付き） */}
           <div>
             <p className="text-[11px] tracking-[0.12em] text-muted-foreground mb-1.5">
@@ -460,7 +495,7 @@ export default function AddTransactionPage() {
         </div>
 
         {/* Memo */}
-        <div className="mt-8">
+        <div className="mt-8 lg:mt-6">
           <p className="text-[11px] tracking-[0.12em] text-muted-foreground mb-1.5">
             メモ
           </p>
@@ -486,7 +521,7 @@ export default function AddTransactionPage() {
         )}
 
         {/* 続けて入力する */}
-        <div className="mt-11 lg:mt-8 mb-5 lg:mb-4 flex items-center justify-center gap-2.5">
+        <div className="mt-11 lg:mt-6 mb-5 lg:mb-4 flex items-center justify-center gap-2.5">
           <button
             type="button"
             role="switch"

--- a/src/lib/data/index.ts
+++ b/src/lib/data/index.ts
@@ -176,6 +176,27 @@ export async function getEntrySuggestions(): Promise<EntrySuggestion[]> {
   return result
 }
 
+// カテゴリ表示順用: 直近3ヶ月の取引からカテゴリ別の使用件数を集計
+export async function getCategoryUsageCounts(): Promise<Record<string, number>> {
+  const since = new Date()
+  since.setMonth(since.getMonth() - 3)
+  const sinceStr = since.toISOString().split("T")[0]
+
+  const { data, error } = await supabase
+    .from("transactions")
+    .select("category_id")
+    .gte("txn_date", sinceStr)
+
+  if (error) throw error
+
+  const counts: Record<string, number> = {}
+  for (const row of data ?? []) {
+    if (!row.category_id) continue
+    counts[row.category_id] = (counts[row.category_id] ?? 0) + 1
+  }
+  return counts
+}
+
 // 振替カテゴリIDを取得（なければ is_active=false で自動作成）
 export async function getOrCreateTransferCategory(userId: string): Promise<string> {
   const { data: existingCats, error: catFetchError } = await supabase


### PR DESCRIPTION
## 背景

TODO-54 (B-11)。iPad横（lg2カラム表示）でカテゴリを14個など多く登録すると、右カラムが縦に伸びて口座選択以下が画面外に見切れ、入力のたびにスクロールが必要だった。

## 変更内容

- `src/lib/data/index.ts`: `getCategoryUsageCounts()` を追加。直近3ヶ月の取引からカテゴリ別使用件数を集計
- `src/app/add/page.tsx`:
  - カテゴリを使用頻度降順にソート（同数・履歴なしは登録順を維持）
  - 9個以上あるときは上位8個＋「すべて表示」タイルに折りたたみ、展開で全カテゴリ表示（「閉じる」で戻る）
  - 選択中カテゴリが上位8外の場合は8個目と入れ替えて折りたたみ中も見えるようにする（サジェスト適用時など）
  - 収支タブ切替時は折りたたみ状態にリセット
  - lgのみ: カテゴリグリッドを5列化し、各セクションの余白・タイルpaddingを詰めて全体を1画面に収める

## 受け入れ基準チェック

- [x] カテゴリ14個のiPad横（1180×820）で金額〜保存ボタンがスクロールなし表示: ダミーカテゴリ14個注入状態で幅1180のコンテンツ全高790px（≤820）をJSで実測、スクショでも確認
- [x] 初期表示は直近3ヶ月の使用頻度順上位8個（履歴なければ登録順）: 集計ロジック＋stable sortで実装、使用実績ありのカテゴリが先頭に並ぶこと実画面確認
- [x] 初期表示外カテゴリも2タップ以内で選択可: 「すべて表示」→カテゴリ選択の2タップを実画面確認
- [x] スマホ幅で全カテゴリ選択可・後退なし: 折りたたみロジックは幅非依存、展開で全カテゴリ選択可。lg未満はlg:クラスが外れるだけであることをコードで確認

## 動作確認

ローカル（localhost:3000/add、ログイン済みセッション）で確認:
- 折りたたみ表示（8個＋すべて表示）、展開（全14個＋閉じる）、隠れカテゴリ選択→折りたたみ後も選択カテゴリが可視、をそれぞれ目視確認
- `npm run build` パス

## レビュー観点

- `getCategoryUsageCounts()` はSupabaseのデフォルト上限（1000行）内での集計。直近3ヶ月の明細が1000件を超えると頻度が不完全になるが、個人利用の規模では実質問題なしと判断
- スマホ幅の実機スクショはChromeウィンドウ最小幅の制約で未取得（ロジックは幅非依存）

🤖 Generated with [Claude Code](https://claude.com/claude-code)