### PR TITLE
feat: 下タブバーをmd以上でもフローティングドックとして表示

### DIFF
--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -238,9 +238,9 @@ export default function AddTransactionPage() {
 
   return (
     <AppLayout>
-      <div className="max-w-[640px] lg:max-w-[1100px] mx-auto px-6 md:px-10 pt-10 pb-16 md:pt-12 md:pb-[72px] lg:pt-10 lg:pb-14">
+      <div className="max-w-[640px] lg:max-w-[1100px] mx-auto px-6 md:px-10 pt-10 pb-16 md:pt-12 md:pb-[72px] lg:pt-8 lg:pb-0">
         {/* Header */}
-        <p className="text-center italic font-serif text-[13px] md:text-sm tracking-[0.14em] text-muted-foreground mb-8 md:mb-10 lg:mb-8">
+        <p className="text-center italic font-serif text-[13px] md:text-sm tracking-[0.14em] text-muted-foreground mb-8 md:mb-10 lg:mb-5">
           Add Entry
         </p>
 

--- a/src/components/app-layout.tsx
+++ b/src/components/app-layout.tsx
@@ -11,7 +11,7 @@ export function AppLayout({ children }: AppLayoutProps) {
   return (
     <div className="min-h-screen bg-background">
       <TopNav />
-      <main className="pb-28 md:pb-0">{children}</main>
+      <main className="pb-28 md:pb-20">{children}</main>
       <BottomNav />
     </div>
   )

--- a/src/components/bottom-nav.tsx
+++ b/src/components/bottom-nav.tsx
@@ -17,8 +17,8 @@ export function BottomNav() {
   const pathname = usePathname()
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 z-50 bg-card/90 backdrop-blur-xl border-t border-border/50 md:hidden">
-      <div className="flex items-center justify-around px-1 pt-2 pb-[calc(0.75rem+env(safe-area-inset-bottom))]">
+    <nav className="fixed bottom-0 left-0 right-0 z-50 bg-card/90 backdrop-blur-xl border-t border-border/50 md:bottom-4 md:left-1/2 md:right-auto md:-translate-x-1/2 md:rounded-full md:border md:border-border/60 md:shadow-lg">
+      <div className="flex items-center justify-around px-1 pt-2 pb-[calc(0.75rem+env(safe-area-inset-bottom))] md:gap-1 md:px-3 md:py-1.5">
         {navItems.map((item) => {
           const isActive = pathname === item.href
           const Icon = item.icon
@@ -28,9 +28,9 @@ export function BottomNav() {
               <Link
                 key={item.href}
                 href={item.href}
-                className="flex flex-col items-center -mt-6"
+                className="flex flex-col items-center -mt-6 md:mt-0"
               >
-                <div className="flex h-14 w-14 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg shadow-primary/25">
+                <div className="flex h-14 w-14 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg shadow-primary/25 md:h-11 md:w-11">
                   <Icon className="h-6 w-6" strokeWidth={2} />
                 </div>
               </Link>


### PR DESCRIPTION
## 背景

md以上（iPad・デスクトップ）では上部ヘッダーのリンクでしかページ移動できず、iPad手持ち時に最も遠い画面上端まで手を伸ばす必要があった。スマホには既に下タブバーがあるため、これをmd以上にも展開する。

## 変更内容

- `bottom-nav.tsx`: `md:hidden` を外し、md以上では中央寄せ・角丸のフローティングドックとして表示（＋ボタンはドック内では通常サイズに）
- `app-layout.tsx`: mainの下パディングを `md:pb-0` → `md:pb-20` にしてスクロール末尾がドックに隠れないように
- `add/page.tsx`: lgの上余白を20px詰めて、ドック表示後も1180×820にスクロールなしで収まるように調整

## 受け入れ基準チェック

- [x] md以上の全ページでドック表示・ページ移動可: ナビは共通AppLayout内。/add・/transactionsで実画面確認、アクティブ強調も動作
- [x] スマホ幅の下タブバーは従来のまま: 追加は全て`md:`プレフィックスクラスのみ、ベーススタイル無変更
- [x] /addのiPad横1180×820収まり維持（PR #35の基準）: ドック実測占有82px（上端738px）に対し保存ボタン下端約714px、クリアランス24px。scrollHeight約794px≤820
- [x] `npm run build` パス

## 動作確認

ローカルで/add・/transactionsをmd幅で表示し、ドックの見た目・アクティブ状態・コンテンツとの重なりなしを目視確認（スクショ取得済み）。ウィンドウ最小幅の制約でスマホ幅の実スクショは未取得（コードで無変更を確認）。

## レビュー観点

- ドック内側の下パディングはモバイル用の `pb-[calc(0.75rem+env(safe-area-inset-bottom))]` と `md:py-1.5` が併存。実画面では意図通りだが、気になるなら `md:pb-1.5` を明示する手もある
- iPad実機（実際の820px高）での見え方はstagingで要確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)